### PR TITLE
Map urls matching github patterns to source code field

### DIFF
--- a/napari_hub_cli/_tests/test_missing_meta.py
+++ b/napari_hub_cli/_tests/test_missing_meta.py
@@ -91,7 +91,8 @@ def test_proj_urls_src(make_pkg_dir):
     f_pth = '/.napari/config.yml'
     section = 'project_urls'
 
-    for url in PROJECT_URLS[1:]:
-        assert url in missing
-        assert (f_pth, section, url) == missing[url].unpack()
+    for url in PROJECT_URLS:
+        if url not in meta:
+            assert url in missing
+            assert (f_pth, section, url) == missing[url].unpack()
 

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -214,3 +214,24 @@ setup(
     ):
         assert key in meta
         assert meta[key].value == value
+
+def test_source_code_url(tmpdir):
+    root_dir = tmpdir.mkdir("test-plugin-name")
+    setup_py_file = root_dir.join("setup.py")
+    proj_site = "https://github.com/user/test-plugin-name"
+
+    setup_py_file.write(
+        f"""
+from setuptools import setup
+
+setup(
+    name = 'test-plugin-name',
+    url = '{proj_site}'
+)
+    """
+    )
+
+    meta = load_meta(root_dir)
+    assert "Project Site" not in meta
+    assert "Source Code" in meta
+    assert meta["Source Code"].value == proj_site    

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -3,6 +3,7 @@ YML_PTH = "/.napari/config.yml"
 SETUP_CFG_PTH = "/setup.cfg"
 SETUP_PY_PTH = "/setup.py"
 DESC_LENGTH = 250
+GITHUB_PATTERN = r'https://github\.com/([^/]+)/([^/]+)'
 
 PROJECT_URLS = [
     "Project Site",

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -1,4 +1,4 @@
-from requests.exceptions import MissingSchema
+import re
 from napari_hub_cli.meta_classes import MetaItem, MetaSource
 import os
 from yaml import full_load
@@ -17,6 +17,7 @@ from .constants import (
     DESC_LENGTH,
     # paths to various configs from root
     DESC_PTH,
+    GITHUB_PATTERN,
     SETUP_CFG_PTH,
     SETUP_PY_PTH,
     YML_PTH,
@@ -54,6 +55,13 @@ def load_meta(pth):
     py_pth = pth + SETUP_PY_PTH
     if os.path.exists(py_pth):
         read_setup_py(meta_dict, py_pth, pth)
+
+    # napari hub will interpret GitHub URLs as Source Code
+    if "Project Site" in meta_dict:
+        if re.match(GITHUB_PATTERN, meta_dict["Project Site"].value) \
+            and "Source Code" not in meta_dict:
+            meta_dict["Source Code"] = meta_dict["Project Site"]
+            del meta_dict["Project Site"]
 
     return meta_dict
 


### PR DESCRIPTION
The napari hub reads github URLs into source code field, update preview tool to do the same