### PR TITLE
Add description as possible source for summary

### DIFF
--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -20,6 +20,7 @@ YML_INFO = list(zip(YML_META, YML_SOURCES))
 SETUP_META = YML_META + [
     "Name",
     "Summary",
+    "Summary",
     "License",
     "Python Version",
 ]
@@ -29,6 +30,7 @@ SETUP_CFG_SOURCES = (
     + YML_SOURCES[2:]
     + [("metadata", "name")]
     + [("metadata", "summary")]
+    + [('metadata', 'description')]
     + [("metadata", "license")]
     + [("options", "python_requires")]
 )
@@ -40,7 +42,7 @@ SETUP_PY_SOURCES = [
 ]
 SETUP_PY_INFO = list(zip(SETUP_META, SETUP_PY_SOURCES))
 
-FIELDS = SETUP_META + [
+FIELDS = list(set(SETUP_META)) + [
     "Description",
     "Operating System",
     "Development Status",


### PR DESCRIPTION
Cookiecutter uses `description` not `summary`, so add this to options we consider.