### PR TITLE
Add numpy to build system requirements for parsesetup install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,6 @@
 markers = [
     "required_configs: Tests will require given template config files",
 ]
+
+[build-system]
+requires = ["setuptools", "wheel", "numpy"]


### PR DESCRIPTION
parsesetup needs numpy installed before setup, add this to build requirements to ensure we can install parsesetup