### PR TITLE
Read metadata sources from CSV rather than maintaining constants

### DIFF
--- a/napari_hub_cli/_tests/conftest.py
+++ b/napari_hub_cli/_tests/conftest.py
@@ -6,6 +6,7 @@ from .config_enum import CONFIG
 
 RESOURCES = Path(napari_hub_cli.__file__).parent / "_tests/resources/"
 
+
 @pytest.fixture
 def make_pkg_dir(tmpdir, request):
     fn_arg_marker = request.node.get_closest_marker("required_configs")

--- a/napari_hub_cli/_tests/test_missing_meta.py
+++ b/napari_hub_cli/_tests/test_missing_meta.py
@@ -3,12 +3,14 @@ from .config_enum import CONFIG
 from napari_hub_cli.napari_hub_cli import get_missing, load_meta
 from napari_hub_cli.constants import FIELDS, PROJECT_URLS, YML_META
 
+
 def assert_cfg_src(meta, missing):
     for field in FIELDS:
-        if field != 'Version' and field not in meta:
+        if field != "Version" and field not in meta:
             assert field in missing
-            if field != 'Description' and field not in YML_META:
-                assert missing[field].src_file == '/setup.cfg'
+            if field != "Description" and field not in YML_META:
+                assert missing[field].src_file == "/setup.cfg"
+
 
 def test_suggested_src_cfg(tmpdir):
     """Test when cfg exists, we suggest cfg as source"""
@@ -26,6 +28,7 @@ name = test-plugin-name
 
     assert_cfg_src(meta, missing)
 
+
 @pytest.mark.required_configs([CONFIG.YML])
 def test_no_setup_suggest_cfg(make_pkg_dir):
     root_dir = make_pkg_dir
@@ -35,6 +38,7 @@ def test_no_setup_suggest_cfg(make_pkg_dir):
 
     assert_cfg_src(meta, missing)
 
+
 @pytest.mark.required_configs([CONFIG.CFG, CONFIG.PY, CONFIG.README])
 def test_both_setup_suggest_cfg(make_pkg_dir):
     root_dir = make_pkg_dir
@@ -42,7 +46,8 @@ def test_both_setup_suggest_cfg(make_pkg_dir):
     meta = load_meta(root_dir)
     missing = get_missing(meta, root_dir)
 
-    assert_cfg_src(meta, missing)    
+    assert_cfg_src(meta, missing)
+
 
 def test_setup_py_no_cfg_suggest_py(tmpdir):
     root_dir = tmpdir.mkdir("test-plugin-name")
@@ -62,9 +67,10 @@ setup(
     for field in FIELDS:
         if field not in meta:
             assert field in missing
-            if field != 'Description' and field not in YML_META:
-                assert missing[field].src_file == '/setup.py'
-                
+            if field != "Description" and field not in YML_META:
+                assert missing[field].src_file == "/setup.py"
+
+
 def test_no_missing_in_full_config(make_pkg_dir):
     root_dir = make_pkg_dir
     meta = load_meta(root_dir)
@@ -81,18 +87,18 @@ def test_description_src(make_pkg_dir):
 
     assert "Description" in missing
     file_pth, _, _ = missing["Description"].unpack()
-    assert file_pth == '/.napari/DESCRIPTION.md'   
+    assert file_pth == "/.napari/DESCRIPTION.md"
+
 
 @pytest.mark.required_configs([CONFIG.CFG])
 def test_proj_urls_src(make_pkg_dir):
     root_dir = make_pkg_dir
     meta = load_meta(root_dir)
     missing = get_missing(meta, root_dir)
-    f_pth = '/.napari/config.yml'
-    section = 'project_urls'
+    f_pth = "/.napari/config.yml"
+    section = "project_urls"
 
     for url in PROJECT_URLS:
         if url not in meta:
             assert url in missing
             assert (f_pth, section, url) == missing[url].unpack()
-

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -215,6 +215,29 @@ setup(
         assert key in meta
         assert meta[key].value == value
 
+def test_setup_cfg_proj_urls(tmpdir):
+    root_dir = tmpdir.mkdir("test-plugin-name")
+    setup_cfg_file = root_dir.join("setup.cfg")
+    proj_site = "https://test-plugin-name.com"
+    twitter = "https://twitter.com/test-plugin-name"
+    bug_tracker = "https://github.com/user/test-plugin-name"
+
+    setup_cfg_file.write(
+        f"""
+[metadata]
+url = {proj_site}
+project_urls =
+    Bug Tracker = {bug_tracker}
+    Twitter = {twitter}
+    """
+    )
+    meta = load_meta(root_dir)
+    for key, value in zip(
+        ["Project Site", "Bug Tracker", "Twitter"], [proj_site, bug_tracker, twitter]
+    ):
+        assert key in meta
+        assert meta[key].value == value
+
 def test_source_code_url(tmpdir):
     root_dir = tmpdir.mkdir("test-plugin-name")
     setup_py_file = root_dir.join("setup.py")

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -215,6 +215,7 @@ setup(
         assert key in meta
         assert meta[key].value == value
 
+
 def test_setup_cfg_proj_urls(tmpdir):
     root_dir = tmpdir.mkdir("test-plugin-name")
     setup_cfg_file = root_dir.join("setup.cfg")
@@ -238,6 +239,7 @@ project_urls =
         assert key in meta
         assert meta[key].value == value
 
+
 def test_source_code_url(tmpdir):
     root_dir = tmpdir.mkdir("test-plugin-name")
     setup_py_file = root_dir.join("setup.py")
@@ -257,4 +259,4 @@ setup(
     meta = load_meta(root_dir)
     assert "Project Site" not in meta
     assert "Source Code" in meta
-    assert meta["Source Code"].value == proj_site    
+    assert meta["Source Code"].value == proj_site

--- a/napari_hub_cli/cli.py
+++ b/napari_hub_cli/cli.py
@@ -47,6 +47,7 @@ def check_missing(args):
                 formatted_missing = format_missing(missing_meta)
                 print(formatted_missing)
 
+
 def parse_args(args):
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers()

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -1,18 +1,22 @@
 import pandas as pd
 import pathlib
 
-SOURCES_CSV = str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_sources.csv"
-USAGE_CSV = str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_usage.csv"
+SOURCES_CSV = (
+    str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_sources.csv"
+)
+USAGE_CSV = (
+    str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_usage.csv"
+)
 
 DESC_PTH = "/.napari/DESCRIPTION.md"
 YML_PTH = "/.napari/config.yml"
 SETUP_CFG_PTH = "/setup.cfg"
 SETUP_PY_PTH = "/setup.py"
 DESC_LENGTH = 250
-GITHUB_PATTERN = r'https://github\.com/([^/]+)/([^/]+)'
+GITHUB_PATTERN = r"https://github\.com/([^/]+)/([^/]+)"
 
 sources_df = pd.read_csv(SOURCES_CSV)
-sources_df = sources_df.where(sources_df != 'None', None)
+sources_df = sources_df.where(sources_df != "None", None)
 
 yml_info = sources_df[sources_df.YML]
 YML_INFO = dict(zip(yml_info.Field, zip(yml_info.YML_Section, yml_info.YML_Key)))
@@ -37,4 +41,6 @@ PROJECT_URLS = [
 YML_META = list(yml_info.Field)
 
 usage_df = pd.read_csv(USAGE_CSV)
-HUB_USES = dict(zip(usage_df.Field, zip(usage_df.Filterable, usage_df.Sortable, usage_df.Searched)))
+HUB_USES = dict(
+    zip(usage_df.Field, zip(usage_df.Filterable, usage_df.Sortable, usage_df.Searched))
+)

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -1,9 +1,28 @@
+import pandas as pd
+import pathlib
+
+SOURCES_CSV = str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_sources.csv"
+
 DESC_PTH = "/.napari/DESCRIPTION.md"
 YML_PTH = "/.napari/config.yml"
 SETUP_CFG_PTH = "/setup.cfg"
 SETUP_PY_PTH = "/setup.py"
 DESC_LENGTH = 250
 GITHUB_PATTERN = r'https://github\.com/([^/]+)/([^/]+)'
+
+sources_df = pd.read_csv(SOURCES_CSV)
+sources_df = sources_df.where(sources_df != 'None', None)
+
+yml_info = sources_df[sources_df.YML]
+YML_INFO = dict(zip(yml_info.Field, zip(yml_info.YML_Section, yml_info.YML_Key)))
+
+cfg_info = sources_df[sources_df.CFG]
+SETUP_CFG_INFO = dict(zip(cfg_info.Field, zip(cfg_info.CFG_Section, cfg_info.CFG_Key)))
+
+py_info = sources_df[sources_df.PY]
+SETUP_PY_INFO = dict(zip(py_info.Field, zip(py_info.PY_Section, py_info.PY_Key)))
+
+FIELDS = list(sources_df.Field)
 
 PROJECT_URLS = [
     "Project Site",
@@ -14,42 +33,46 @@ PROJECT_URLS = [
     "Bug Tracker",
 ]
 
-YML_META = ["Authors"] + PROJECT_URLS
-YML_SOURCES = [("authors", None)] + [("project_urls", url) for url in PROJECT_URLS]
-YML_INFO = list(zip(YML_META, YML_SOURCES))
+YML_META = list(yml_info.Field)
 
-SETUP_META = YML_META + [
-    "Name",
-    "Summary",
-    "Summary",
-    "License",
-    "Python Version",
-]
-SETUP_CFG_SOURCES = (
-    [("metadata", "author")]
-    + [("metadata", "url")]
-    + YML_SOURCES[2:]
-    + [("metadata", "name")]
-    + [("metadata", "summary")]
-    + [('metadata', 'description')]
-    + [("metadata", "license")]
-    + [("options", "python_requires")]
-)
-SETUP_CFG_INFO = list(zip(SETUP_META, SETUP_CFG_SOURCES))
+# YML_META = ["Authors"] + PROJECT_URLS
+# YML_SOURCES = [("authors", None)] + [("project_urls", url) for url in PROJECT_URLS]
+# YML_INFO = list(zip(YML_META, YML_SOURCES))
 
-SETUP_PY_SOURCES = [
-    (None, key) if section != "project_urls" else (section, key)
-    for (section, key) in SETUP_CFG_SOURCES
-]
-SETUP_PY_INFO = list(zip(SETUP_META, SETUP_PY_SOURCES))
+# SETUP_META = YML_META + [
+#     "Name",
+#     "Summary",
+#     "Summary",
+#     "License",
+#     "Python Version",
+# ]
+# SETUP_CFG_SOURCES = (
+#     [("metadata", "author")]
+#     + [("metadata", "url")]
+#     + YML_SOURCES[2:]
+#     + [("metadata", "name")]
+#     + [("metadata", "summary")]
+#     + [('metadata', 'description')]
+#     + [("metadata", "license")]
+#     + [("options", "python_requires")]
+# )
+# SETUP_CFG_INFO = list(zip(SETUP_META, SETUP_CFG_SOURCES))
 
-FIELDS = sorted(list(set(SETUP_META)) + [
-    "Description",
-    "Operating System",
-    "Development Status",
-    "Requirements",
-    "Version",
-])
+# SETUP_PY_SOURCES = [
+#     (None, key) if section != "project_urls" else (section, key)
+#     for (section, key) in SETUP_CFG_SOURCES
+# ]
+# SETUP_PY_INFO = list(zip(SETUP_META, SETUP_PY_SOURCES))
+
+# FIELDS = sorted(list(set(SETUP_META)) + [
+#     "Description",
+#     "Operating System",
+#     "Development Status",
+#     "Requirements",
+#     "Version",
+# ])
+
+
 
 FILTERABLE = [
     False,

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -23,7 +23,7 @@ SETUP_CFG_INFO = dict(zip(cfg_info.Field, zip(cfg_info.CFG_Section, cfg_info.CFG
 py_info = sources_df[sources_df.PY]
 SETUP_PY_INFO = dict(zip(py_info.Field, zip(py_info.PY_Section, py_info.PY_Key)))
 
-FIELDS = list(sources_df.Field)
+FIELDS = list(set(sources_df.Field))
 
 PROJECT_URLS = [
     "Project Site",
@@ -38,63 +38,3 @@ YML_META = list(yml_info.Field)
 
 usage_df = pd.read_csv(USAGE_CSV)
 HUB_USES = dict(zip(usage_df.Field, zip(usage_df.Filterable, usage_df.Sortable, usage_df.Searched)))
-
-# FILTERABLE = [
-#     False,
-#     False,
-#     False,
-#     True,
-#     False,
-#     True,
-#     False,
-#     True,
-#     False,
-#     True,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-# ]
-
-# SORTABLE = [
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     True,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-# ]
-
-# SEARCHED = [
-#     True,
-#     False,
-#     True,
-#     False,
-#     False,
-#     False,
-#     True,
-#     False,
-#     False,
-#     False,
-#     False,
-#     False,
-#     True,
-#     False,
-#     False,
-#     False,
-# ]
-
-# USES = zip(FILTERABLE, SORTABLE, SEARCHED)
-# HUB_USES = dict(zip(FIELDS, USES))

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pathlib
 
 SOURCES_CSV = str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_sources.csv"
+USAGE_CSV = str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_usage.csv"
 
 DESC_PTH = "/.napari/DESCRIPTION.md"
 YML_PTH = "/.napari/config.yml"
@@ -35,101 +36,65 @@ PROJECT_URLS = [
 
 YML_META = list(yml_info.Field)
 
-# YML_META = ["Authors"] + PROJECT_URLS
-# YML_SOURCES = [("authors", None)] + [("project_urls", url) for url in PROJECT_URLS]
-# YML_INFO = list(zip(YML_META, YML_SOURCES))
+usage_df = pd.read_csv(USAGE_CSV)
+HUB_USES = dict(zip(usage_df.Field, zip(usage_df.Filterable, usage_df.Sortable, usage_df.Searched)))
 
-# SETUP_META = YML_META + [
-#     "Name",
-#     "Summary",
-#     "Summary",
-#     "License",
-#     "Python Version",
+# FILTERABLE = [
+#     False,
+#     False,
+#     False,
+#     True,
+#     False,
+#     True,
+#     False,
+#     True,
+#     False,
+#     True,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
 # ]
-# SETUP_CFG_SOURCES = (
-#     [("metadata", "author")]
-#     + [("metadata", "url")]
-#     + YML_SOURCES[2:]
-#     + [("metadata", "name")]
-#     + [("metadata", "summary")]
-#     + [('metadata', 'description')]
-#     + [("metadata", "license")]
-#     + [("options", "python_requires")]
-# )
-# SETUP_CFG_INFO = list(zip(SETUP_META, SETUP_CFG_SOURCES))
 
-# SETUP_PY_SOURCES = [
-#     (None, key) if section != "project_urls" else (section, key)
-#     for (section, key) in SETUP_CFG_SOURCES
+# SORTABLE = [
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     True,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
 # ]
-# SETUP_PY_INFO = list(zip(SETUP_META, SETUP_PY_SOURCES))
 
-# FIELDS = sorted(list(set(SETUP_META)) + [
-#     "Description",
-#     "Operating System",
-#     "Development Status",
-#     "Requirements",
-#     "Version",
-# ])
+# SEARCHED = [
+#     True,
+#     False,
+#     True,
+#     False,
+#     False,
+#     False,
+#     True,
+#     False,
+#     False,
+#     False,
+#     False,
+#     False,
+#     True,
+#     False,
+#     False,
+#     False,
+# ]
 
-
-
-FILTERABLE = [
-    False,
-    False,
-    False,
-    True,
-    False,
-    True,
-    False,
-    True,
-    False,
-    True,
-    False,
-    False,
-    False,
-    False,
-    False,
-    False,
-]
-
-SORTABLE = [
-    False,
-    False,
-    False,
-    False,
-    False,
-    False,
-    True,
-    False,
-    False,
-    False,
-    False,
-    False,
-    False,
-    False,
-    False,
-    False,
-]
-
-SEARCHED = [
-    True,
-    False,
-    True,
-    False,
-    False,
-    False,
-    True,
-    False,
-    False,
-    False,
-    False,
-    False,
-    True,
-    False,
-    False,
-    False,
-]
-
-USES = zip(FILTERABLE, SORTABLE, SEARCHED)
-HUB_USES = dict(zip(FIELDS, USES))
+# USES = zip(FILTERABLE, SORTABLE, SEARCHED)
+# HUB_USES = dict(zip(FIELDS, USES))

--- a/napari_hub_cli/formatting.py
+++ b/napari_hub_cli/formatting.py
@@ -5,6 +5,7 @@ from .constants import (
     HUB_USES,
 )
 
+
 def format_missing(missing_meta):
     rep_str = ""
     for field, suggested_source in missing_meta.items():
@@ -28,13 +29,15 @@ def format_missing_field(field, suggested_source):
     rep_str += "\n"
     return rep_str
 
+
 def print_missing_interactive(missing_meta):
     for field, suggested_source in missing_meta.items():
         rep_str = format_missing_field(field, suggested_source)
         print(rep_str)
-        quit = input("Enter to continue (any to quit)>>>")    
+        quit = input("Enter to continue (any to quit)>>>")
         if quit:
             break
+
 
 def format_meta(meta, missing_meta):
     rep_str = ""
@@ -47,9 +50,10 @@ def print_meta_interactive(meta, missing_meta):
     for field in sorted(FIELDS):
         rep_str = format_field(field, meta, missing_meta)
         print(rep_str)
-        quit = input("Enter to continue (any to quit)>>>")    
+        quit = input("Enter to continue (any to quit)>>>")
         if quit:
             break
+
 
 def format_source(src):
     rep_str = ""

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -11,6 +11,7 @@ from .utils import (
     get_pkg_version,
     is_canonical,
     split_dangling_list,
+    split_project_urls
 )
 from .constants import (
     # length of description to preview
@@ -87,7 +88,10 @@ def read_yml_config(meta_dict, yml_path):
 
 def read_setup_cfg(meta_dict, setup_path, root_pth):
     c_parser = ConfigParser()
+    c_parser.optionxform = str
     c_parser.read(setup_path)
+
+    split_project_urls(c_parser)
 
     for field, (section, key) in SETUP_CFG_INFO.items():
         if section in c_parser.sections():

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -37,11 +37,8 @@ def load_meta(pth):
         with open(desc_pth) as desc_file:
             full_desc = desc_file.read()
             if full_desc:
-                trimmed_desc = full_desc[:DESC_LENGTH]
-                if len(trimmed_desc) == DESC_LENGTH:
-                    trimmed_desc += "..."
                 desc_source = MetaSource(DESC_PTH)
-                desc_item = MetaItem("Description", trimmed_desc, desc_source)
+                desc_item = MetaItem("Description", full_desc, desc_source)
                 meta_dict[desc_item.field_name] = desc_item
 
     yml_pth = pth + YML_PTH
@@ -63,13 +60,20 @@ def load_meta(pth):
             meta_dict["Source Code"] = meta_dict["Project Site"]
             del meta_dict["Project Site"]
 
+    # trim long description so we're not printing the whole file
+    if "Description" in meta_dict:
+        trimmed_desc = meta_dict['Description'].value
+        if len(trimmed_desc) > DESC_LENGTH:
+            trimmed_desc = trimmed_desc[:DESC_LENGTH] + "..."
+        meta_dict["Description"].value = trimmed_desc
+
     return meta_dict
 
 
 def read_yml_config(meta_dict, yml_path):
     with open(yml_path) as yml_file:
         yml_meta = full_load(yml_file)
-        for field_name, (section, key) in YML_INFO:
+        for field_name, (section, key) in YML_INFO.items():
             if section in yml_meta:
                 if key and key in yml_meta[section]:
                     src = MetaSource(YML_PTH, section, key)
@@ -85,7 +89,7 @@ def read_setup_cfg(meta_dict, setup_path, root_pth):
     c_parser = ConfigParser()
     c_parser.read(setup_path)
 
-    for field, (section, key) in SETUP_CFG_INFO:
+    for field, (section, key) in SETUP_CFG_INFO.items():
         if section in c_parser.sections():
             if key in c_parser[section]:
                 if meta_dict[field] is None:
@@ -99,7 +103,7 @@ def read_setup_cfg(meta_dict, setup_path, root_pth):
 
 def read_setup_py(meta_dict, setup_path, root_pth):
     setup_args = parsesetup.parse_setup(os.path.abspath(setup_path), trusted=True)
-    for field, (section, key) in SETUP_PY_INFO:
+    for field, (section, key) in SETUP_PY_INFO.items():
         if section:
             # project urls are the only fields with a section
             if section in setup_args:
@@ -152,7 +156,7 @@ def parse_complex_meta(meta_dict, config, root_pth, cfg_pth):
                 version_source = MetaSource(cfg_pth, section, "version")
         version_item.source = version_source
 
-    if meta_dict["Description"] is None:
+    if "Description" not in meta_dict or 'file:' in meta_dict["Description"].value:
         long_desc = get_long_description(config, root_pth)
         if long_desc:
             desc_source = MetaSource(cfg_pth, section, "long_description")
@@ -173,7 +177,7 @@ def parse_complex_meta(meta_dict, config, root_pth, cfg_pth):
 
 def get_missing(meta, pth):
     missing_meta = defaultdict(None)
-    for field, source in YML_INFO:
+    for field, source in YML_INFO.items():
         if field not in meta:
             section, key = source
             src_item = MetaSource(YML_PTH, section, key)
@@ -193,7 +197,7 @@ def get_missing(meta, pth):
         suggested_cfg = SETUP_PY_PTH
         cfg_info = SETUP_PY_INFO
     
-    for field, src in cfg_info:
+    for field, src in cfg_info.items():
         if field not in meta and field not in missing_meta:
             section, key = src
             src_item = MetaSource(suggested_cfg, section, key)

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -11,7 +11,7 @@ from .utils import (
     get_pkg_version,
     is_canonical,
     split_dangling_list,
-    split_project_urls
+    split_project_urls,
 )
 from .constants import (
     # length of description to preview
@@ -56,14 +56,16 @@ def load_meta(pth):
 
     # napari hub will interpret GitHub URLs as Source Code
     if "Project Site" in meta_dict:
-        if re.match(GITHUB_PATTERN, meta_dict["Project Site"].value) \
-            and "Source Code" not in meta_dict:
+        if (
+            re.match(GITHUB_PATTERN, meta_dict["Project Site"].value)
+            and "Source Code" not in meta_dict
+        ):
             meta_dict["Source Code"] = meta_dict["Project Site"]
             del meta_dict["Project Site"]
 
     # trim long description so we're not printing the whole file
     if "Description" in meta_dict:
-        trimmed_desc = meta_dict['Description'].value
+        trimmed_desc = meta_dict["Description"].value
         if len(trimmed_desc) > DESC_LENGTH:
             trimmed_desc = trimmed_desc[:DESC_LENGTH] + "..."
         meta_dict["Description"].value = trimmed_desc
@@ -160,7 +162,7 @@ def parse_complex_meta(meta_dict, config, root_pth, cfg_pth):
                 version_source = MetaSource(cfg_pth, section, "version")
         version_item.source = version_source
 
-    if "Description" not in meta_dict or 'file:' in meta_dict["Description"].value:
+    if "Description" not in meta_dict or "file:" in meta_dict["Description"].value:
         long_desc = get_long_description(config, root_pth)
         if long_desc:
             desc_source = MetaSource(cfg_pth, section, "long_description")
@@ -200,26 +202,26 @@ def get_missing(meta, pth):
     else:
         suggested_cfg = SETUP_PY_PTH
         cfg_info = SETUP_PY_INFO
-    
+
     for field, src in cfg_info.items():
         if field not in meta and field not in missing_meta:
             section, key = src
             src_item = MetaSource(suggested_cfg, section, key)
             missing_meta[field] = src_item
 
-    for field in ["Operating System","Development Status"]:
+    for field in ["Operating System", "Development Status"]:
         section = None
         if field not in meta:
             if suggested_cfg == SETUP_CFG_PTH:
-                section = 'metadata'
-            src_item = MetaSource(suggested_cfg, section, 'classifiers')
+                section = "metadata"
+            src_item = MetaSource(suggested_cfg, section, "classifiers")
             missing_meta[field] = src_item
-    
+
     section = None
     if "Requirements" not in meta:
         if suggested_cfg == SETUP_CFG_PTH:
-            section = 'options'
-        src_item = MetaSource(suggested_cfg, section, 'install_requires')
-        missing_meta["Requirements"] = src_item        
+            section = "options"
+        src_item = MetaSource(suggested_cfg, section, "install_requires")
+        missing_meta["Requirements"] = src_item
 
     return missing_meta

--- a/napari_hub_cli/resources/metadata_sources.csv
+++ b/napari_hub_cli/resources/metadata_sources.csv
@@ -1,18 +1,18 @@
 Field,YML,CFG,PY,YML_Section,YML_Key,CFG_Section,CFG_Key,PY_Section,PY_Key
 Authors,True,True,True,authors,None,metadata,author,None,author
-Bug Tracker,True,True,True,project_urls,Bug Tracker,metadata,project_urls,project_urls,Bug Tracker
+Bug Tracker,True,True,True,project_urls,Bug Tracker,project_urls,Bug Tracker,project_urls,Bug Tracker
 Description,False,True,True,None,None,metadata,long_description,None,long_description
 Development Status,False,True,True,None,None,metadata,classifiers,None,classifiers
-Documentation,True,True,True,project_urls,Documentation,metadata,project_urls,project_urls,Documentation
+Documentation,True,True,True,project_urls,Documentation,project_urls,Documentation,project_urls,Documentation
 License,False,True,True,None,None,metadata,license,None,license
 Name,False,True,True,None,None,metadata,name,None,name
 Operating System,False,True,True,None,None,metadata,classifiers,None,classifiers
 Project Site,True,True,True,project_urls,Project Site,metadata,url,None,url
 Python Version,False,True,True,None,None,options,python_requires,None,python_requires
 Requirements,False,True,True,None,None,options,install_requires,None,install_requires
-Source Code,True,True,True,project_urls,Source Code,metadata,project_urls,project_urls,Source Code
+Source Code,True,True,True,project_urls,Source Code,project_urls,Source Code,project_urls,Source Code
 Summary,True,True,True,summary,None,metadata,summary,None,summary
 Summary,True,True,True,summary,None,metadata,description,None,description
-Twitter,True,True,True,project_urls,Twitter,metadata,project_urls,project_urls,Twitter
-User Support,True,True,True,project_urls,User Support,metadata,project_urls,project_urls,User Support
+Twitter,True,True,True,project_urls,Twitter,project_urls,Twitter,project_urls,Twitter
+User Support,True,True,True,project_urls,User Support,project_urls,User Support,project_urls,User Support
 Version,False,True,True,None,None,metadata,version,None,version

--- a/napari_hub_cli/resources/metadata_sources.csv
+++ b/napari_hub_cli/resources/metadata_sources.csv
@@ -1,0 +1,18 @@
+Field,YML,CFG,PY,YML_Section,YML_Key,CFG_Section,CFG_Key,PY_Section,PY_Key
+Authors,True,True,True,authors,None,metadata,author,None,author
+Bug Tracker,True,True,True,project_urls,Bug Tracker,metadata,project_urls,project_urls,Bug Tracker
+Description,False,True,True,None,None,metadata,long_description,None,long_description
+Development Status,False,True,True,None,None,metadata,classifiers,None,classifiers
+Documentation,True,True,True,project_urls,Documentation,metadata,project_urls,project_urls,Documentation
+License,False,True,True,None,None,metadata,license,None,license
+Name,False,True,True,None,None,metadata,name,None,name
+Operating System,False,True,True,None,None,metadata,classifiers,None,classifiers
+Project Site,True,True,True,project_urls,Project Site,metadata,url,None,url
+Python Version,False,True,True,None,None,options,python_requires,None,python_requires
+Requirements,False,True,True,None,None,options,install_requires,None,install_requires
+Source Code,True,True,True,project_urls,Source Code,metadata,project_urls,project_urls,Source Code
+Summary,True,True,True,summary,None,metadata,summary,None,summary
+Summary,True,True,True,summary,None,metadata,description,None,description
+Twitter,True,True,True,project_urls,Twitter,metadata,project_urls,project_urls,Twitter
+User Support,True,True,True,project_urls,User Support,metadata,project_urls,project_urls,User Support
+Version,False,True,True,None,None,metadata,version,None,version

--- a/napari_hub_cli/resources/metadata_usage.csv
+++ b/napari_hub_cli/resources/metadata_usage.csv
@@ -1,0 +1,17 @@
+Field,Filterable,Sortable,Searched
+Authors,False,False,True
+Bug Tracker,False,False,False
+Description,False,False,True
+Development Status,True,False,False
+Documentation,False,False,False
+License,True,False,False
+Name,False,True,True
+Operating System,True,False,False
+Project Site,False,False,False
+Python Version,True,False,False
+Requirements,False,False,False
+Source Code,False,False,False
+Summary,False,False,True
+Twitter,False,False,False
+User Support,False,False,False
+Version,False,False,False

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -1,9 +1,7 @@
 import re
-import re
 import glob
 import codecs
 import os
-from .constants import DESC_LENGTH
 
 
 def flatten(config_parser):
@@ -119,6 +117,20 @@ def split_dangling_list(dangling_list_str):
     str_trimmed = dangling_list_str.lstrip().rstrip()
     val_list = str_trimmed.split("\n")
     return val_list
+
+
+def split_project_urls(config):
+    if 'metadata' in config.sections() and 'project_urls' in config['metadata']:
+        url_str = config['metadata']['project_urls']
+        del config['metadata']['project_urls']
+
+        url_list = split_dangling_list(url_str)
+        url_dict = {}
+        for url in url_list:
+            split_url = url.split(" = ")
+            url_dict[split_url[0]] = split_url[1]
+        
+        config['project_urls'] = url_dict
 
 
 def is_canonical(version):

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -25,10 +25,7 @@ def get_long_description(given_meta, root_pth):
                     full_desc = desc_file.read()
         else:
             full_desc = given_meta["long_description"]
-    trimmed_desc = full_desc[:DESC_LENGTH]
-    if len(trimmed_desc) and len(trimmed_desc) == DESC_LENGTH:
-        trimmed_desc += "..."
-    return trimmed_desc
+    return full_desc
 
 
 def parse_setuptools_version(f_pth):

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -120,17 +120,17 @@ def split_dangling_list(dangling_list_str):
 
 
 def split_project_urls(config):
-    if 'metadata' in config.sections() and 'project_urls' in config['metadata']:
-        url_str = config['metadata']['project_urls']
-        del config['metadata']['project_urls']
+    if "metadata" in config.sections() and "project_urls" in config["metadata"]:
+        url_str = config["metadata"]["project_urls"]
+        del config["metadata"]["project_urls"]
 
         url_list = split_dangling_list(url_str)
         url_dict = {}
         for url in url_list:
             split_url = url.split(" = ")
             url_dict[split_url[0]] = split_url[1]
-        
-        config['project_urls'] = url_dict
+
+        config["project_urls"] = url_dict
 
 
 def is_canonical(version):

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     numpy       # required for parsesetup import
+    pandas
     parsesetup
     PyYAML
 [options.entry_points]


### PR DESCRIPTION
Constants were awful to read and a terrible source of truth. Move to 2 CSVs - one for all metadata sources from any of the three config files, the other for how the fields are used on the hub.