### PR TITLE
Dev status is no longer being used for filtering

### DIFF
--- a/napari_hub_cli/resources/metadata_usage.csv
+++ b/napari_hub_cli/resources/metadata_usage.csv
@@ -2,7 +2,7 @@ Field,Filterable,Sortable,Searched
 Authors,False,False,True
 Bug Tracker,False,False,False
 Description,False,False,True
-Development Status,True,False,False
+Development Status,False,False,False
 Documentation,False,False,False
 License,True,False,False
 Name,False,True,True


### PR DESCRIPTION
Dev status will not be used for filtering for the foreseeable future - update usage CSV to reflect this.