### PR TITLE
Ping GitHub API for License when Source Code field is provided

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -39,6 +39,7 @@ jobs:
         run: tox -r
         env:
           PLATFORM: ${{ matrix.platform }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Coverage
         uses: codecov/codecov-action@v1

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -8,6 +8,7 @@ from napari_hub_cli.meta_classes import MetaItem
 
 DEMO_GITHUB_REPO = "https://github.com/DragaDoncila/example-plugin"
 
+
 @pytest.mark.required_configs([CONFIG.YML])
 def test_config_yml(make_pkg_dir):
     root_dir = make_pkg_dir
@@ -262,19 +263,21 @@ setup(
     assert "Source Code" in meta
     assert meta["Source Code"].value == proj_site
 
+
 def test_github_license():
     meta = {}
     meta["Source Code"] = MetaItem("Source Code", DEMO_GITHUB_REPO)
-    
+
     github_api_license = get_github_license(meta)
     assert github_api_license == "BSD-3-Clause"
+
 
 def test_github_license_overrides_local(tmpdir):
     root_dir = tmpdir.mkdir("test-plugin-name")
     setup_cfg_file = root_dir.join("setup.cfg")
 
     setup_cfg_file.write(
-    f"""
+        f"""
 [metadata]
 license = MIT
 project_urls =
@@ -284,6 +287,6 @@ project_urls =
     meta = load_meta(root_dir)
 
     assert "License" in meta
-    license_src = meta["License"].source 
+    license_src = meta["License"].source
     assert license_src.src_file == "GitHub Repository"
-    assert meta["License"].value == 'BSD-3-Clause'    
+    assert meta["License"].value == "BSD-3-Clause"

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -1,11 +1,12 @@
-from napari_hub_cli.meta_classes import MetaItem
 import os
 import pytest
-from yaml import load
 from .config_enum import CONFIG
 from napari_hub_cli.napari_hub_cli import load_meta
 from napari_hub_cli.constants import FIELDS, PROJECT_URLS, DESC_LENGTH
+from napari_hub_cli.utils import get_github_license
+from napari_hub_cli.meta_classes import MetaItem
 
+DEMO_GITHUB_REPO = "https://github.com/DragaDoncila/example-plugin"
 
 @pytest.mark.required_configs([CONFIG.YML])
 def test_config_yml(make_pkg_dir):
@@ -260,3 +261,29 @@ setup(
     assert "Project Site" not in meta
     assert "Source Code" in meta
     assert meta["Source Code"].value == proj_site
+
+def test_github_license():
+    meta = {}
+    meta["Source Code"] = MetaItem("Source Code", DEMO_GITHUB_REPO)
+    
+    github_api_license = get_github_license(meta)
+    assert github_api_license == "BSD-3-Clause"
+
+def test_github_license_overrides_local(tmpdir):
+    root_dir = tmpdir.mkdir("test-plugin-name")
+    setup_cfg_file = root_dir.join("setup.cfg")
+
+    setup_cfg_file.write(
+    f"""
+[metadata]
+license = MIT
+project_urls =
+    Source Code = {DEMO_GITHUB_REPO}
+"""
+    )
+    meta = load_meta(root_dir)
+
+    assert "License" in meta
+    license_src = meta["License"].source 
+    assert license_src.src_file == "GitHub Repository"
+    assert meta["License"].value == 'BSD-3-Clause'    

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 from .utils import (
     flatten,
     filter_classifiers,
+    get_github_license,
     get_long_description,
     get_pkg_version,
     is_canonical,
@@ -62,6 +63,9 @@ def load_meta(pth):
         ):
             meta_dict["Source Code"] = meta_dict["Project Site"]
             del meta_dict["Project Site"]
+
+    # see if we can get a license from GitHub API
+    github_license = get_github_license(meta_dict)
 
     # trim long description so we're not printing the whole file
     if "Description" in meta_dict:

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -66,6 +66,10 @@ def load_meta(pth):
 
     # see if we can get a license from GitHub API
     github_license = get_github_license(meta_dict)
+    if github_license:
+        license_src = MetaSource("GitHub Repository")
+        license_item = MetaItem("License", github_license, license_src)
+        meta_dict[license_item.field_name] = license_item
 
     # trim long description so we're not printing the whole file
     if "Description" in meta_dict:

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -41,7 +41,7 @@ def parse_setuptools_version(f_pth):
                 version_number_split = version_number.split(delim)
                 if len(version_number_split) > 1:
                     return version_number_split[1]
-                else: 
+                else:
                     return None
 
 
@@ -65,15 +65,18 @@ def get_github_license(meta):
     """
     if "Source Code" in meta and re.match(GITHUB_PATTERN, meta["Source Code"].value):
         repo_url = meta["Source Code"].value
-        api_url = repo_url.replace("https://github.com/",
-                              "https://api.github.com/repos/")
+        api_url = repo_url.replace(
+            "https://github.com/", "https://api.github.com/repos/"
+        )
         try:
-            response = requests.get(f'{api_url}/license')
+            response = requests.get(f"{api_url}/license")
             if response.status_code != requests.codes.ok:
                 response.raise_for_status()
             response_json = json.loads(response.text.strip())
-            if 'license' in response_json and 'spdx_id' in response_json['license']: 
-                return response_json['license']["spdx_id"]
+            if "license" in response_json and "spdx_id" in response_json["license"]:
+                spdx_id = response_json["license"]["spdx_id"]
+                if spdx_id != "NOASSERTION":
+                    return spdx_id
         except HTTPError:
             return None
 
@@ -111,7 +114,7 @@ def get_pkg_version(given_meta, root_pth):
     search_pth = os.path.join(root_pth, "**")
     pkg_files = glob.glob(search_pth, recursive=True)
     for f_pth in pkg_files:
-        if 'build' not in f_pth and 'dist' not in f_pth:
+        if "build" not in f_pth and "dist" not in f_pth:
             mtch = re.match(version_file_regex, os.path.basename(f_pth).lower())
             if mtch:
                 # ends with .py - likely setuptools-scm

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -63,8 +63,8 @@ def get_github_license(meta):
     str
         the license spdx identifier, or None
     """
-    if meta["Source Code"] and re.match(GITHUB_PATTERN, meta["Source Code"]):
-        repo_url = meta["Source Code"]
+    if "Source Code" in meta and re.match(GITHUB_PATTERN, meta["Source Code"].value):
+        repo_url = meta["Source Code"].value
         api_url = repo_url.replace("https://github.com/",
                               "https://api.github.com/repos/")
         try:

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -63,13 +63,18 @@ def get_github_license(meta):
     str
         the license spdx identifier, or None
     """
+    github_token = os.environ.get('GITHUB_TOKEN')
+    auth_header = None
+    if github_token:
+        auth_header = {'Authorization': f'token {github_token}'}
+
     if "Source Code" in meta and re.match(GITHUB_PATTERN, meta["Source Code"].value):
         repo_url = meta["Source Code"].value
         api_url = repo_url.replace(
             "https://github.com/", "https://api.github.com/repos/"
         )
         try:
-            response = requests.get(f"{api_url}/license")
+            response = requests.get(f"{api_url}/license", headers=auth_header)
             if response.status_code != requests.codes.ok:
                 response.raise_for_status()
             response_json = json.loads(response.text.strip())

--- a/tox.ini
+++ b/tox.ini
@@ -20,6 +20,8 @@ platform =
     windows: win32
 setenv =
     PYTHONPATH = {toxinidir}
+passenv =
+    GITHUB_TOKEN
 deps = 
     numpy
 commands =


### PR DESCRIPTION
The hub is now preferring GitHub licenses where available over the PyPI license field.

Update napari-hub-cli to query license information from the API whenever the Source Code field is provided and is a valid github URL. Still falling back to PyPI license when Source Code is missing or the API does not provide a license.