### PR TITLE
Update basecode

### DIFF
--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -36,7 +36,7 @@ jobs:
           pip install setuptools tox tox-gh-actions
 
       - name: Test with tox
-        run: tox -r
+        run: tox -r -e py
         env:
           PLATFORM: ${{ matrix.platform }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -1,6 +1,6 @@
 name: tests
 
-on: 
+on:
   push:
     branches:
       - master
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test_main.yml
+++ b/.github/workflows/test_main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ repos:
     hooks:
     - id: isort
 -   repo: https://github.com/psf/black
-    rev: 21.12b0
+    rev: 22.10.0
     hooks:
     - id: black
       pass_filenames: true
 -   repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     - id: flake8
       additional_dependencies: [flake8-typing-imports==1.11.0]
@@ -17,7 +17,7 @@ repos:
       args:
         - "--max-line-length=88"
 -   repo: https://github.com/seddonym/import-linter
-    rev: v1.2.6
+    rev: v1.4.0
     hooks:
     - id: import-linter
       stages: [manual]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-inclue napari_hub_cli/resources/metadata_sources.csv
+include napari_hub_cli/resources/metadata_sources.csv
 include napari_hub_cli/resources/metadata_usage.csv
 
 include README.md

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,7 @@
 ignore:
   - napari_hub_cli/formatting.py
   - napari_hub_cli/cli.py
+  - napari_hub_cli/_tests
 coverage:
   status:
     project:

--- a/napari_hub_cli/_tests/config_enum.py
+++ b/napari_hub_cli/_tests/config_enum.py
@@ -10,3 +10,6 @@ class CONFIG(Enum):
     SCM_VERS = ("test_plugin_name", "_version.py")
     VERS = "VERSION"
     README = "README.md"
+
+
+DEMO_GITHUB_REPO = "https://github.com/DragaDoncila/example-plugin"

--- a/napari_hub_cli/_tests/conftest.py
+++ b/napari_hub_cli/_tests/conftest.py
@@ -1,4 +1,3 @@
-import os
 from pathlib import Path
 
 import pytest
@@ -11,23 +10,25 @@ RESOURCES = Path(napari_hub_cli.__file__).parent / "_tests/resources/"
 
 
 @pytest.fixture
-def make_pkg_dir(tmpdir, request):
+def make_pkg_dir(tmp_path, request):
     fn_arg_marker = request.node.get_closest_marker("required_configs")
     if fn_arg_marker:
         needed_configs = fn_arg_marker.args[0]
     else:
         needed_configs = CONFIG
 
-    root_dir = tmpdir.mkdir("test-plugin-name")
+    root_dir = tmp_path / "test-plugin-name"
+    root_dir.mkdir()
     for cfg in needed_configs:
         fn = cfg.value
         if isinstance(fn, tuple):
-            if not os.path.exists(os.path.join(root_dir, fn[0])):
-                new_fn = root_dir.mkdir(fn[0]).join(fn[1])
-                current_fn = os.path.join(RESOURCES, os.path.join(fn[0], fn[1]))
+            new_dir = root_dir / fn[0]
+            new_dir.mkdir(exist_ok=True)
+            new_fn = new_dir / fn[1]
+            current_fn = RESOURCES / Path(fn[0]) / Path(fn[1])
         else:
-            new_fn = root_dir.join(fn)
-            current_fn = os.path.join(RESOURCES, fn)
-        with open(current_fn) as template:
-            new_fn.write(template.read())
+            new_fn = root_dir / fn
+            current_fn = RESOURCES / fn
+        with open(current_fn, "r") as template:
+            new_fn.write_text(template.read())
     return root_dir

--- a/napari_hub_cli/_tests/conftest.py
+++ b/napari_hub_cli/_tests/conftest.py
@@ -1,12 +1,45 @@
 from pathlib import Path
 
 import pytest
+import requests_mock
 
 import napari_hub_cli
 
-from .config_enum import CONFIG
+from .config_enum import CONFIG, DEMO_GITHUB_REPO
 
 RESOURCES = Path(napari_hub_cli.__file__).parent / "_tests/resources/"
+MOCK_REQUESTS = None
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--online",
+        action="store_true",
+        default=False,
+        help="runs tests with an internet access for requests",
+    )
+
+
+def pytest_configure(config):
+    if config.getoption("--online"):
+        return
+    global MOCK_REQUESTS
+    MOCK_REQUESTS = requests_mock.Mocker()  # general mock
+    MOCK_REQUESTS.start()
+    # mock everything to an empty json
+    MOCK_REQUESTS.register_uri("GET", requests_mock.ANY, json={})
+    # mock calls to the demo repository
+    with open(RESOURCES / "license.json", "r", encoding="utf-8") as license:
+        repository_url = DEMO_GITHUB_REPO
+        api_url = repository_url.replace(
+            "https://github.com/", "https://api.github.com/repos/"
+        )
+        MOCK_REQUESTS.register_uri("GET", f"{api_url}/license", text=license.read())
+
+
+def pytest_unconfigure(config):
+    if MOCK_REQUESTS is not None:
+        MOCK_REQUESTS.stop()
 
 
 @pytest.fixture

--- a/napari_hub_cli/_tests/resources/license.json
+++ b/napari_hub_cli/_tests/resources/license.json
@@ -1,0 +1,25 @@
+{
+    "name": "LICENSE",
+    "path": "LICENSE",
+    "sha": "2310609d98a678e628dd468d6024a882add4b9ee",
+    "size": 1490,
+    "url": "https://api.github.com/repos/DragaDoncila/example-plugin/contents/LICENSE?ref=main",
+    "html_url": "https://github.com/DragaDoncila/example-plugin/blob/main/LICENSE",
+    "git_url": "https://api.github.com/repos/DragaDoncila/example-plugin/git/blobs/2310609d98a678e628dd468d6024a882add4b9ee",
+    "download_url": "https://raw.githubusercontent.com/DragaDoncila/example-plugin/main/LICENSE",
+    "type": "file",
+    "content": "CkNvcHlyaWdodCAoYykgMjAyMSwgRHJhZ2EgRG9uY2lsYSBQb3AKQWxsIHJp\nZ2h0cyByZXNlcnZlZC4KClJlZGlzdHJpYnV0aW9uIGFuZCB1c2UgaW4gc291\ncmNlIGFuZCBiaW5hcnkgZm9ybXMsIHdpdGggb3Igd2l0aG91dAptb2RpZmlj\nYXRpb24sIGFyZSBwZXJtaXR0ZWQgcHJvdmlkZWQgdGhhdCB0aGUgZm9sbG93\naW5nIGNvbmRpdGlvbnMgYXJlIG1ldDoKCiogUmVkaXN0cmlidXRpb25zIG9m\nIHNvdXJjZSBjb2RlIG11c3QgcmV0YWluIHRoZSBhYm92ZSBjb3B5cmlnaHQg\nbm90aWNlLCB0aGlzCiAgbGlzdCBvZiBjb25kaXRpb25zIGFuZCB0aGUgZm9s\nbG93aW5nIGRpc2NsYWltZXIuCgoqIFJlZGlzdHJpYnV0aW9ucyBpbiBiaW5h\ncnkgZm9ybSBtdXN0IHJlcHJvZHVjZSB0aGUgYWJvdmUgY29weXJpZ2h0IG5v\ndGljZSwKICB0aGlzIGxpc3Qgb2YgY29uZGl0aW9ucyBhbmQgdGhlIGZvbGxv\nd2luZyBkaXNjbGFpbWVyIGluIHRoZSBkb2N1bWVudGF0aW9uCiAgYW5kL29y\nIG90aGVyIG1hdGVyaWFscyBwcm92aWRlZCB3aXRoIHRoZSBkaXN0cmlidXRp\nb24uCgoqIE5laXRoZXIgdGhlIG5hbWUgb2YgZXhhbXBsZS1wbHVnaW4gbm9y\nIHRoZSBuYW1lcyBvZiBpdHMKICBjb250cmlidXRvcnMgbWF5IGJlIHVzZWQg\ndG8gZW5kb3JzZSBvciBwcm9tb3RlIHByb2R1Y3RzIGRlcml2ZWQgZnJvbQog\nIHRoaXMgc29mdHdhcmUgd2l0aG91dCBzcGVjaWZpYyBwcmlvciB3cml0dGVu\nIHBlcm1pc3Npb24uCgpUSElTIFNPRlRXQVJFIElTIFBST1ZJREVEIEJZIFRI\nRSBDT1BZUklHSFQgSE9MREVSUyBBTkQgQ09OVFJJQlVUT1JTICJBUyBJUyIK\nQU5EIEFOWSBFWFBSRVNTIE9SIElNUExJRUQgV0FSUkFOVElFUywgSU5DTFVE\nSU5HLCBCVVQgTk9UIExJTUlURUQgVE8sIFRIRQpJTVBMSUVEIFdBUlJBTlRJ\nRVMgT0YgTUVSQ0hBTlRBQklMSVRZIEFORCBGSVRORVNTIEZPUiBBIFBBUlRJ\nQ1VMQVIgUFVSUE9TRSBBUkUKRElTQ0xBSU1FRC4gSU4gTk8gRVZFTlQgU0hB\nTEwgVEhFIENPUFlSSUdIVCBIT0xERVIgT1IgQ09OVFJJQlVUT1JTIEJFIExJ\nQUJMRQpGT1IgQU5ZIERJUkVDVCwgSU5ESVJFQ1QsIElOQ0lERU5UQUwsIFNQ\nRUNJQUwsIEVYRU1QTEFSWSwgT1IgQ09OU0VRVUVOVElBTApEQU1BR0VTIChJ\nTkNMVURJTkcsIEJVVCBOT1QgTElNSVRFRCBUTywgUFJPQ1VSRU1FTlQgT0Yg\nU1VCU1RJVFVURSBHT09EUyBPUgpTRVJWSUNFUzsgTE9TUyBPRiBVU0UsIERB\nVEEsIE9SIFBST0ZJVFM7IE9SIEJVU0lORVNTIElOVEVSUlVQVElPTikgSE9X\nRVZFUgpDQVVTRUQgQU5EIE9OIEFOWSBUSEVPUlkgT0YgTElBQklMSVRZLCBX\nSEVUSEVSIElOIENPTlRSQUNULCBTVFJJQ1QgTElBQklMSVRZLApPUiBUT1JU\nIChJTkNMVURJTkcgTkVHTElHRU5DRSBPUiBPVEhFUldJU0UpIEFSSVNJTkcg\nSU4gQU5ZIFdBWSBPVVQgT0YgVEhFIFVTRQpPRiBUSElTIFNPRlRXQVJFLCBF\nVkVOIElGIEFEVklTRUQgT0YgVEhFIFBPU1NJQklMSVRZIE9GIFNVQ0ggREFN\nQUdFLgo=\n",
+    "encoding": "base64",
+    "_links": {
+      "self": "https://api.github.com/repos/DragaDoncila/example-plugin/contents/LICENSE?ref=main",
+      "git": "https://api.github.com/repos/DragaDoncila/example-plugin/git/blobs/2310609d98a678e628dd468d6024a882add4b9ee",
+      "html": "https://github.com/DragaDoncila/example-plugin/blob/main/LICENSE"
+    },
+    "license": {
+      "key": "bsd-3-clause",
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "spdx_id": "BSD-3-Clause",
+      "url": "https://api.github.com/licenses/bsd-3-clause",
+      "node_id": "MDc6TGljZW5zZTU="
+    }
+  }

--- a/napari_hub_cli/_tests/test_missing_meta.py
+++ b/napari_hub_cli/_tests/test_missing_meta.py
@@ -14,19 +14,24 @@ def assert_cfg_src(meta, missing):
                 assert missing[field].src_file == "/setup.cfg"
 
 
-def test_suggested_src_cfg(tmpdir):
+def test_cfg_fields_non_empty():
+    assert len(FIELDS) > 0  # necessary to avoid potential rotten green tests
+
+
+def test_suggested_src_cfg(tmp_path):
     """Test when cfg exists, we suggest cfg as source"""
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_cfg_file = root_dir.join("setup.cfg")
-    setup_cfg_file.write(
+    root_dir = tmp_path / "test-suggested-src-cfg"
+    root_dir.mkdir()
+    setup_cfg_file = root_dir / "setup.cfg"
+    setup_cfg_file.write_text(
         """
 [metadata]
 name = test-plugin-name
     """
     )
 
-    meta = load_meta(root_dir)
-    missing = get_missing(meta, root_dir)
+    meta = load_meta(f"{root_dir}")
+    missing = get_missing(meta, f"{root_dir}")
 
     assert_cfg_src(meta, missing)
 
@@ -51,11 +56,12 @@ def test_both_setup_suggest_cfg(make_pkg_dir):
     assert_cfg_src(meta, missing)
 
 
-def test_setup_py_no_cfg_suggest_py(tmpdir):
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_py_file = root_dir.join("setup.py")
+def test_setup_py_no_cfg_suggest_py(tmp_path):
+    root_dir = tmp_path / "test-plugin-name"
+    root_dir.mkdir()
+    setup_py_file = root_dir / "setup.py"
 
-    setup_py_file.write(
+    setup_py_file.write_text(
         """
 from setuptools import setup
 
@@ -64,8 +70,8 @@ setup(
 )
     """
     )
-    meta = load_meta(root_dir)
-    missing = get_missing(meta, root_dir)
+    meta = load_meta(f"{root_dir}")
+    missing = get_missing(meta, f"{root_dir}")
     for field in FIELDS:
         if field not in meta:
             assert field in missing

--- a/napari_hub_cli/_tests/test_missing_meta.py
+++ b/napari_hub_cli/_tests/test_missing_meta.py
@@ -11,7 +11,7 @@ def assert_cfg_src(meta, missing):
         if field != "Version" and field not in meta:
             assert field in missing
             if field != "Description" and field not in YML_META:
-                assert missing[field].src_file == "/setup.cfg"
+                assert missing[field].src_file == "setup.cfg"
 
 
 def test_cfg_fields_non_empty():
@@ -30,8 +30,8 @@ name = test-plugin-name
     """
     )
 
-    meta = load_meta(f"{root_dir}")
-    missing = get_missing(meta, f"{root_dir}")
+    meta = load_meta(root_dir)
+    missing = get_missing(meta, root_dir)
 
     assert_cfg_src(meta, missing)
 
@@ -70,13 +70,13 @@ setup(
 )
     """
     )
-    meta = load_meta(f"{root_dir}")
-    missing = get_missing(meta, f"{root_dir}")
+    meta = load_meta(root_dir)
+    missing = get_missing(meta, root_dir)
     for field in FIELDS:
         if field not in meta:
             assert field in missing
             if field != "Description" and field not in YML_META:
-                assert missing[field].src_file == "/setup.py"
+                assert missing[field].src_file == "setup.py"
 
 
 def test_no_missing_in_full_config(make_pkg_dir):
@@ -95,7 +95,7 @@ def test_description_src(make_pkg_dir):
 
     assert "Description" in missing
     file_pth, _, _ = missing["Description"].unpack()
-    assert file_pth == "/.napari/DESCRIPTION.md"
+    assert file_pth == ".napari/DESCRIPTION.md"
 
 
 @pytest.mark.required_configs([CONFIG.CFG])
@@ -103,7 +103,7 @@ def test_proj_urls_src(make_pkg_dir):
     root_dir = make_pkg_dir
     meta = load_meta(root_dir)
     missing = get_missing(meta, root_dir)
-    f_pth = "/.napari/config.yml"
+    f_pth = ".napari/config.yml"
     section = "project_urls"
 
     for url in PROJECT_URLS:

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -86,8 +86,8 @@ def test_cfg_description(make_pkg_dir):
 @pytest.mark.required_configs([CONFIG.INIT])
 def test_version_init_setup_cfg(make_pkg_dir):
     root_dir = make_pkg_dir
-    stup = root_dir.join("setup.cfg")
-    stup.write("[metadata]\nname = test-plugin-name")
+    stup = root_dir / "setup.cfg"
+    stup.write_text("[metadata]\nname = test-plugin-name")
 
     meta = load_meta(root_dir)
 
@@ -100,8 +100,8 @@ def test_version_init_setup_cfg(make_pkg_dir):
 @pytest.mark.required_configs([CONFIG.INIT])
 def test_version_init_setup_py(make_pkg_dir):
     root_dir = make_pkg_dir
-    stup = root_dir.join("setup.py")
-    stup.write("from setuptools import setup\nsetup()")
+    stup = root_dir / "setup.py"
+    stup.write_text("from setuptools import setup\nsetup()")
 
     meta = load_meta(root_dir)
 
@@ -114,8 +114,8 @@ def test_version_init_setup_py(make_pkg_dir):
 @pytest.mark.required_configs([CONFIG.SCM_VERS])
 def test_version_scm(make_pkg_dir):
     root_dir = make_pkg_dir
-    stup = root_dir.join("setup.py")
-    stup.write("from setuptools import setup\nsetup()")
+    stup = root_dir / "setup.py"
+    stup.write_text("from setuptools import setup\nsetup()")
 
     meta = load_meta(root_dir)
 
@@ -128,8 +128,8 @@ def test_version_scm(make_pkg_dir):
 @pytest.mark.required_configs([CONFIG.VERS])
 def test_version_file(make_pkg_dir):
     root_dir = make_pkg_dir
-    stup = root_dir.join("setup.py")
-    stup.write("from setuptools import setup\nsetup()")
+    stup = root_dir / "setup.py"
+    stup.write_text("from setuptools import setup\nsetup()")
 
     meta = load_meta(root_dir)
 
@@ -161,16 +161,18 @@ def test_fields_have_source(make_pkg_dir):
 def test_long_description_trimmed(make_pkg_dir):
     root_dir = make_pkg_dir
     long_desc = "*" * DESC_LENGTH * 2
-    readme = root_dir.join("README.md")
-    readme.write(long_desc)
+    readme = root_dir / "README.md"
+    readme.write_text(long_desc)
 
     meta = load_meta(root_dir)
     # trimmed description plus the dots
     assert len(meta["Description"].value) == DESC_LENGTH + 3
 
     # same for DESCRIPTION.md
-    desc = root_dir.mkdir(".napari").join("DESCRIPTION.md")
-    desc.write(long_desc)
+    napari_dir = root_dir / ".napari"
+    napari_dir.mkdir()
+    desc = napari_dir / "DESCRIPTION.md"
+    desc.write_text(long_desc)
     meta = load_meta(root_dir)
     assert meta["Description"].source.src_file == ".napari/DESCRIPTION.md"
     assert len(meta["Description"].value) == DESC_LENGTH + 3

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -7,9 +7,7 @@ from napari_hub_cli.meta_classes import MetaItem
 from napari_hub_cli.napari_hub_cli import load_meta
 from napari_hub_cli.utils import get_github_license
 
-from .config_enum import CONFIG
-
-DEMO_GITHUB_REPO = "https://github.com/DragaDoncila/example-plugin"
+from .config_enum import CONFIG, DEMO_GITHUB_REPO
 
 
 @pytest.mark.required_configs([CONFIG.YML])

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -21,7 +21,7 @@ def test_config_yml(make_pkg_dir):
         # all project urls have been read and are sourced from config yml
         assert proj_url in meta_dict
         f_pth, section, key = meta_dict[proj_url].source.unpack()
-        assert f_pth == "/.napari/config.yml"
+        assert f_pth == ".napari/config.yml"
         assert section == "project_urls"
         assert key == proj_url
 
@@ -34,7 +34,7 @@ def test_config_yml(make_pkg_dir):
     assert meta_dict["Authors"].value[0]["name"] == "Jane Doe"
     assert len(meta_dict["Authors"].value) == 2
     f_pth, section, key = meta_dict["Authors"].source.unpack()
-    assert f_pth == "/.napari/config.yml"
+    assert f_pth == ".napari/config.yml"
     assert section == "authors"
     assert key is None
 
@@ -48,7 +48,7 @@ def test_config_yml_not_overriden(make_pkg_dir):
         # all project urls have been read and are sourced from config yml
         assert proj_url in meta_dict
         f_pth, section, key = meta_dict[proj_url].source.unpack()
-        assert f_pth == "/.napari/config.yml"
+        assert f_pth == ".napari/config.yml"
         assert section == "project_urls"
         assert key == proj_url
 
@@ -66,7 +66,7 @@ def test_description_not_overriden(make_pkg_dir):
 
     assert meta_dict["Description"].value == "Test .napari Description."
     f_pth, section, key = meta_dict["Description"].source.unpack()
-    assert f_pth == "/.napari/DESCRIPTION.md"
+    assert f_pth == ".napari/DESCRIPTION.md"
     assert section is None
     assert key is None
 
@@ -78,7 +78,7 @@ def test_cfg_description(make_pkg_dir):
 
     assert meta_dict["Description"].value == "Test README Description."
     f_pth, section, key = meta_dict["Description"].source.unpack()
-    assert f_pth == "/setup.cfg"
+    assert f_pth == "setup.cfg"
     assert section == "metadata"
     assert key == "long_description"
 
@@ -172,7 +172,7 @@ def test_long_description_trimmed(make_pkg_dir):
     desc = root_dir.mkdir(".napari").join("DESCRIPTION.md")
     desc.write(long_desc)
     meta = load_meta(root_dir)
-    assert meta["Description"].source.src_file == "/.napari/DESCRIPTION.md"
+    assert meta["Description"].source.src_file == ".napari/DESCRIPTION.md"
     assert len(meta["Description"].value) == DESC_LENGTH + 3
 
 

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -176,10 +176,11 @@ def test_long_description_trimmed(make_pkg_dir):
     assert len(meta["Description"].value) == DESC_LENGTH + 3
 
 
-def test_long_description_cfg(tmpdir):
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_cfg_file = root_dir.join("setup.cfg")
-    setup_cfg_file.write(
+def test_long_description_cfg(tmp_path):
+    root_dir = tmp_path / "test-long-description"
+    root_dir.mkdir()
+    setup_cfg_file = root_dir / "setup.cfg"
+    setup_cfg_file.write_text(
         f"""
 [metadata]
 name = test-plugin-name
@@ -187,19 +188,20 @@ long_description = {'*' * DESC_LENGTH*2}
     """
     )
 
-    meta = load_meta(root_dir)
+    meta = load_meta(f"{root_dir}")
     assert "Description" in meta
     assert len(meta["Description"].value) == DESC_LENGTH + 3
 
 
-def test_setup_py_proj_urls(tmpdir):
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_py_file = root_dir.join("setup.py")
+def test_setup_py_proj_urls(tmp_path):
+    root_dir = tmp_path / "test-setup-py-proj-urls"
+    root_dir.mkdir()
+    setup_py_file = root_dir / "setup.py"
     proj_site = "https://test-plugin-name.com"
     twitter = "https://twitter.com/test-plugin-name"
     bug_tracker = "https://github.com/user/test-plugin-name"
 
-    setup_py_file.write(
+    setup_py_file.write_text(
         f"""
 from setuptools import setup
 
@@ -213,7 +215,7 @@ setup(
 )
     """
     )
-    meta = load_meta(root_dir)
+    meta = load_meta(f"{root_dir}")
     for key, value in zip(
         ["Project Site", "Bug Tracker", "Twitter"], [proj_site, bug_tracker, twitter]
     ):
@@ -221,14 +223,15 @@ setup(
         assert meta[key].value == value
 
 
-def test_setup_cfg_proj_urls(tmpdir):
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_cfg_file = root_dir.join("setup.cfg")
+def test_setup_cfg_proj_urls(tmp_path):
+    root_dir = tmp_path / "test-setup-cfg-proj-urls"
+    root_dir.mkdir()
+    setup_cfg_file = root_dir / "setup.cfg"
     proj_site = "https://test-plugin-name.com"
     twitter = "https://twitter.com/test-plugin-name"
     bug_tracker = "https://github.com/user/test-plugin-name"
 
-    setup_cfg_file.write(
+    setup_cfg_file.write_text(
         f"""
 [metadata]
 url = {proj_site}
@@ -237,7 +240,7 @@ project_urls =
     Twitter = {twitter}
     """
     )
-    meta = load_meta(root_dir)
+    meta = load_meta(f"{root_dir}")
     for key, value in zip(
         ["Project Site", "Bug Tracker", "Twitter"], [proj_site, bug_tracker, twitter]
     ):
@@ -245,12 +248,13 @@ project_urls =
         assert meta[key].value == value
 
 
-def test_source_code_url(tmpdir):
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_py_file = root_dir.join("setup.py")
+def test_source_code_url(tmp_path):
+    root_dir = tmp_path / "test-source-code-url"
+    root_dir.mkdir()
+    setup_py_file = root_dir / "setup.py"
     proj_site = "https://github.com/user/test-plugin-name"
 
-    setup_py_file.write(
+    setup_py_file.write_text(
         f"""
 from setuptools import setup
 
@@ -261,7 +265,7 @@ setup(
     """
     )
 
-    meta = load_meta(root_dir)
+    meta = load_meta(f"{root_dir}")
     assert "Project Site" not in meta
     assert "Source Code" in meta
     assert meta["Source Code"].value == proj_site
@@ -275,11 +279,12 @@ def test_github_license():
     assert github_api_license == "BSD-3-Clause"
 
 
-def test_github_license_overrides_local(tmpdir):
-    root_dir = tmpdir.mkdir("test-plugin-name")
-    setup_cfg_file = root_dir.join("setup.cfg")
+def test_github_license_overrides_local(tmp_path):
+    root_dir = tmp_path / "test-github-license-overrides-local"
+    root_dir.mkdir()
+    setup_cfg_file = root_dir / "setup.cfg"
 
-    setup_cfg_file.write(
+    setup_cfg_file.write_text(
         f"""
 [metadata]
 license = MIT
@@ -287,8 +292,7 @@ project_urls =
     Source Code = {DEMO_GITHUB_REPO}
 """
     )
-    meta = load_meta(root_dir)
-
+    meta = load_meta(f"{root_dir}")
     assert "License" in meta
     license_src = meta["License"].source
     assert license_src.src_file == "GitHub Repository"

--- a/napari_hub_cli/_tests/test_preview_meta.py
+++ b/napari_hub_cli/_tests/test_preview_meta.py
@@ -5,7 +5,7 @@ import pytest
 from napari_hub_cli.constants import DESC_LENGTH, FIELDS, PROJECT_URLS
 from napari_hub_cli.meta_classes import MetaItem
 from napari_hub_cli.napari_hub_cli import load_meta
-from napari_hub_cli.utils import get_github_license
+from napari_hub_cli.utils import get_github_license, parse_setup
 
 from .config_enum import CONFIG, DEMO_GITHUB_REPO
 
@@ -297,3 +297,14 @@ project_urls =
     license_src = meta["License"].source
     assert license_src.src_file == "GitHub Repository"
     assert meta["License"].value == "BSD-3-Clause"
+
+
+def test_parse_wrong_setup_py(tmp_path):
+    root_dir = tmp_path / "test-parse-wrong-setup-file"
+    root_dir.mkdir()
+    setup_file = root_dir / "other.py"
+
+    setup_file.write_text("print('do nothing')")
+
+    with pytest.raises(ValueError):
+        parse_setup(setup_file)

--- a/napari_hub_cli/cli.py
+++ b/napari_hub_cli/cli.py
@@ -4,8 +4,12 @@ import argparse
 import os
 import sys
 
-from .formatting import (format_meta, format_missing, print_meta_interactive,
-                         print_missing_interactive)
+from .formatting import (
+    format_meta,
+    format_missing,
+    print_meta_interactive,
+    print_missing_interactive,
+)
 from .napari_hub_cli import get_missing, load_meta
 
 

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -1,7 +1,29 @@
 """This file contains constants for finding Python package metadata in a directory"""
 import pathlib
+from ast import literal_eval
+from csv import DictReader
 
-import pandas as pd
+
+def read_csv(filepath):
+    def parse_value(v):
+        try:
+            return literal_eval(v)
+        except Exception:
+            return v
+
+    with open(filepath, "r", newline="") as f:
+        reader = DictReader(f)
+        return [{k: parse_value(v) for k, v in row.items()} for row in reader]
+
+
+def extract_config_infos(sources, kind):
+    infos = tuple(row for row in sources if row.get(kind, False))
+    return extract_infos(infos, (f"{kind}_Section", f"{kind}_Key"))
+
+
+def extract_infos(infos, columns, key="Field"):
+    return {info[key]: tuple(info[k] for k in columns) for info in infos}
+
 
 """
 this csv contains a mapping for each metadata field to all possible sources
@@ -12,14 +34,11 @@ section `metadata`, key `authors` in setup.cfg
 we keep this information to be able to tell the user where to find metadata,
 or add it if it's missing
 """
-SOURCES_CSV = (
-    str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_sources.csv"
-)
+_PARENT_PATH = pathlib.Path(__file__).parent.absolute()
+SOURCES_CSV = f"{_PARENT_PATH}/resources/metadata_sources.csv"
 # this csv maps each field to a bool for whether it is used for searching,
 # filtering and/or sorting on the napari hub
-USAGE_CSV = (
-    str(pathlib.Path(__file__).parent.absolute()) + "/resources/metadata_usage.csv"
-)
+USAGE_CSV = f"{_PARENT_PATH}/resources/metadata_usage.csv"
 
 # standard paths from root folder to the various metadata files
 DESC_PTH = "/.napari/DESCRIPTION.md"
@@ -32,20 +51,13 @@ DESC_LENGTH = 250
 # regex to match github urls
 GITHUB_PATTERN = r"https://github\.com/([^/]+)/([^/]+)"
 
-sources_df = pd.read_csv(SOURCES_CSV)
-sources_df = sources_df.where(sources_df != "None", None)
-
 # here we split the sources df into the relevant fields for each metadata file
-yml_info = sources_df[sources_df.YML]
-YML_INFO = dict(zip(yml_info.Field, zip(yml_info.YML_Section, yml_info.YML_Key)))
+sources = read_csv(SOURCES_CSV)
+YML_INFO = extract_config_infos(sources, "YML")
+SETUP_CFG_INFO = extract_config_infos(sources, "CFG")
+SETUP_PY_INFO = extract_config_infos(sources, "PY")
 
-cfg_info = sources_df[sources_df.CFG]
-SETUP_CFG_INFO = dict(zip(cfg_info.Field, zip(cfg_info.CFG_Section, cfg_info.CFG_Key)))
-
-py_info = sources_df[sources_df.PY]
-SETUP_PY_INFO = dict(zip(py_info.Field, zip(py_info.PY_Section, py_info.PY_Key)))
-
-FIELDS = list(set(sources_df.Field))
+FIELDS = list(set(info["Field"] for info in sources))
 
 # various URLs the plugin developer can provide that may be displayed on the hub
 PROJECT_URLS = [
@@ -57,9 +69,7 @@ PROJECT_URLS = [
     "Bug Tracker",
 ]
 
-YML_META = list(yml_info.Field)
+YML_META = YML_INFO
 
-usage_df = pd.read_csv(USAGE_CSV)
-HUB_USES = dict(
-    zip(usage_df.Field, zip(usage_df.Filterable, usage_df.Sortable, usage_df.Searched))
-)
+usage = read_csv(USAGE_CSV)
+HUB_USES = extract_infos(usage, ("Filterable", "Sortable", "Searched"))

--- a/napari_hub_cli/constants.py
+++ b/napari_hub_cli/constants.py
@@ -41,10 +41,10 @@ SOURCES_CSV = f"{_PARENT_PATH}/resources/metadata_sources.csv"
 USAGE_CSV = f"{_PARENT_PATH}/resources/metadata_usage.csv"
 
 # standard paths from root folder to the various metadata files
-DESC_PTH = "/.napari/DESCRIPTION.md"
-YML_PTH = "/.napari/config.yml"
-SETUP_CFG_PTH = "/setup.cfg"
-SETUP_PY_PTH = "/setup.py"
+DESC_PTH = ".napari/DESCRIPTION.md"
+YML_PTH = ".napari/config.yml"
+SETUP_CFG_PTH = "setup.cfg"
+SETUP_PY_PTH = "setup.py"
 
 # max characters to print for the description
 DESC_LENGTH = 250

--- a/napari_hub_cli/formatting.py
+++ b/napari_hub_cli/formatting.py
@@ -103,8 +103,8 @@ def format_field(field, meta, missing_meta):
         val = meta_item.value
         src = meta_item.source
         if isinstance(val, list):
-            for i in range(len(val)):
-                rep_str += f"{val[i]}\n"
+            for v in val:
+                rep_str += f"{v}\n"
         else:
             rep_str += f"{val}\n"
         if src:

--- a/napari_hub_cli/meta_classes.py
+++ b/napari_hub_cli/meta_classes.py
@@ -1,26 +1,20 @@
 """Metadata classes mainly to support the use of named attributes"""
+from dataclasses import dataclass
 from typing import Dict, List, Optional, Union
 
 
+@dataclass
 class MetaSource:
-    def __init__(
-        self, src_file: str, section: Optional[str] = None, key: Optional[str] = None
-    ) -> None:
-        self.src_file = src_file
-        self.section = section
-        self.key = key
+    src_file: str
+    section: Optional[str] = None
+    key: Optional[str] = None
 
     def unpack(self):
         return self.src_file, self.section, self.key
 
 
+@dataclass
 class MetaItem:
-    def __init__(
-        self,
-        field_name: str,
-        value: Union[str, List[Union[str, Dict[str, str]]]],
-        source: Optional[MetaSource] = None,
-    ) -> None:
-        self.field_name = field_name
-        self.value = value
-        self.source = source
+    field_name: str
+    value: Union[str, List[Union[str, Dict[str, str]]]]
+    source: Optional[MetaSource] = None

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -3,7 +3,7 @@ import re
 from collections import defaultdict
 from configparser import ConfigParser
 
-import parsesetup
+from .utils import parse_setup
 from yaml import full_load
 
 from napari_hub_cli.meta_classes import MetaItem, MetaSource
@@ -164,7 +164,7 @@ def read_setup_py(meta_dict, setup_path, root_pth):
     root_pth : str
         path to root of package, used to try searching version
     """
-    setup_args = parsesetup.parse_setup(os.path.abspath(setup_path), trusted=True)
+    setup_args = parse_setup(os.path.abspath(setup_path))
     for field, (section, key) in SETUP_PY_INFO.items():
         if field not in meta_dict:
             if section:

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -48,7 +48,7 @@ def load_meta(pth):
     Dict[str, MetaItem]
         dictionary of loaded metadata
     """
-    meta_dict = defaultdict(lambda: None)
+    meta_dict = {}
 
     # try to read .napari/DESCRIPTION.md if available
     desc_pth = pth + DESC_PTH

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -51,7 +51,7 @@ def load_meta(pth):
     meta_dict = {}
 
     # try to read .napari/DESCRIPTION.md if available
-    desc_pth = pth + DESC_PTH
+    desc_pth = f"{pth}/{DESC_PTH}"
     if os.path.exists(desc_pth):
         with open(desc_pth) as desc_file:
             full_desc = desc_file.read()
@@ -61,17 +61,17 @@ def load_meta(pth):
                 meta_dict[desc_item.field_name] = desc_item
 
     # read .napari/config.yml for authors and project urls
-    yml_pth = pth + YML_PTH
+    yml_pth = f"{pth}/{YML_PTH}"
     if os.path.exists(yml_pth):
         read_yml_config(meta_dict, yml_pth)
 
     # read all metadata available in setup.cfg
-    cfg_pth = pth + SETUP_CFG_PTH
+    cfg_pth = f"{pth}/{SETUP_CFG_PTH}"
     if os.path.exists(cfg_pth):
         read_setup_cfg(meta_dict, cfg_pth, pth)
 
     # finally, try to read from setup.py
-    py_pth = pth + SETUP_PY_PTH
+    py_pth = f"{pth}/{SETUP_PY_PTH}"
     if os.path.exists(py_pth):
         read_setup_py(meta_dict, py_pth, pth)
 
@@ -311,8 +311,8 @@ def get_missing(meta, pth):
         src_item = MetaSource(DESC_PTH)
         missing_meta["Description"] = src_item
 
-    cfg_pth = pth + SETUP_CFG_PTH
-    py_pth = pth + SETUP_PY_PTH
+    cfg_pth = f"{pth}/{SETUP_CFG_PTH}"
+    py_pth = f"{pth}/{SETUP_PY_PTH}"
     # if we already have a cfg or if we don't have setup.py, we prefer setup.cfg
     if os.path.exists(cfg_pth) or not os.path.exists(py_pth):
         suggested_cfg = SETUP_CFG_PTH

--- a/napari_hub_cli/napari_hub_cli.py
+++ b/napari_hub_cli/napari_hub_cli.py
@@ -3,17 +3,32 @@ import re
 from collections import defaultdict
 from configparser import ConfigParser
 
-from .utils import parse_setup
 from yaml import full_load
 
 from napari_hub_cli.meta_classes import MetaItem, MetaSource
 
-from .constants import (DESC_LENGTH, DESC_PTH, GITHUB_PATTERN, SETUP_CFG_INFO,
-                        SETUP_CFG_PTH, SETUP_PY_INFO, SETUP_PY_PTH, YML_INFO,
-                        YML_PTH)
-from .utils import (filter_classifiers, flatten, get_github_license,
-                    get_long_description, get_pkg_version, is_canonical,
-                    split_dangling_list, split_project_urls)
+from .constants import (
+    DESC_LENGTH,
+    DESC_PTH,
+    GITHUB_PATTERN,
+    SETUP_CFG_INFO,
+    SETUP_CFG_PTH,
+    SETUP_PY_INFO,
+    SETUP_PY_PTH,
+    YML_INFO,
+    YML_PTH,
+)
+from .utils import (
+    filter_classifiers,
+    flatten,
+    get_github_license,
+    get_long_description,
+    get_pkg_version,
+    is_canonical,
+    parse_setup,
+    split_dangling_list,
+    split_project_urls,
+)
 
 
 def load_meta(pth):

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -169,7 +169,7 @@ def get_pkg_version(given_meta, root_pth):
     version_file_regex = r"^_*version_*(.py)?$"
     pkg_version = (
         "We could not parse the version of your package."
-        + " Check PyPi for your latest version."
+        " Check PyPi for your latest version."
     )
 
     # literal version resolved in meta

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -3,9 +3,9 @@ import glob
 import json
 import os
 import re
-import setuptools
 
 import requests
+import setuptools
 from requests.exceptions import HTTPError
 
 from .constants import GITHUB_PATTERN

--- a/napari_hub_cli/utils.py
+++ b/napari_hub_cli/utils.py
@@ -1,8 +1,8 @@
 import codecs
 import glob
-import json
 import os
 import re
+from contextlib import suppress
 
 import requests
 import setuptools
@@ -117,17 +117,15 @@ def get_github_license(meta):
         api_url = repo_url.replace(
             "https://github.com/", "https://api.github.com/repos/"
         )
-        try:
+        with suppress(HTTPError):
             response = requests.get(f"{api_url}/license", headers=auth_header)
             if response.status_code != requests.codes.ok:
                 response.raise_for_status()
-            response_json = json.loads(response.text.strip())
+            response_json = response.json()
             if "license" in response_json and "spdx_id" in response_json["license"]:
                 spdx_id = response_json["license"]["spdx_id"]
                 if spdx_id != "NOASSERTION":
                     return spdx_id
-        except HTTPError:
-            return None
 
 
 def get_init_version(rel_path):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,8 +1,4 @@
-pip
-wheel
-flake8
+pre-commit
 tox
-coverage
 pytest
 pytest-cov
-parsesetup

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@ pre-commit
 tox
 pytest
 pytest-cov
+requests-mock

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ url = https://github.com/chanzuckerberg/napari-hub-cli
 description= Command line utilities for inspecting and validating plugins for the napari hub
 long_description = file: README.md
 long_description_content_type = text/markdown
-classifiers = 
+classifiers =
     Development Status :: 2 - Pre-Alpha
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
@@ -22,17 +22,16 @@ classifiers =
 [options]
 packages = find:
 python_requires = >=3.6
-setup_requires = 
+setup_requires =
     setuptools_scm
 install_requires =
     numpy       # required for parsesetup import
-    pandas
     parsesetup
     PyYAML
 include_package_data=True
 
 [options.entry_points]
-console_scripts = 
+console_scripts =
     napari-hub-cli = napari_hub_cli.cli:main
 
 [flake8]

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,6 @@ python_requires = >=3.6
 setup_requires =
     setuptools_scm
 install_requires =
-    numpy       # required for parsesetup import
-    parsesetup
     PyYAML
 include_package_data=True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,8 @@ classifiers =
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
@@ -26,6 +28,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     PyYAML
+    requests
 include_package_data=True
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ classifiers =
     License :: OSI Approved :: BSD License
     Natural Language :: English
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,13 @@
 [tox]
-envlist = py{37,38,39}-{linux,macos,windows}
+envlist = py{37,38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
+    "3.10": py310
     3.9: py39
     3.8: py38
     3.7: py37
+    3.6: py36
 
 [gh-actions:env]
 PLATFORM =
@@ -14,7 +16,7 @@ PLATFORM =
     windows-latest: windows
 
 [testenv]
-platform = 
+platform =
     macos: darwin
     linux: linux
     windows: win32
@@ -22,9 +24,8 @@ setenv =
     PYTHONPATH = {toxinidir}
 passenv =
     GITHUB_TOKEN
-deps = 
-    numpy
 commands =
-    pip install -r requirements_dev.txt
+    pip install -e .
+    pip install -U pytest pytest-cov coverage
     pytest --basetemp={envtmpdir} --color=yes --cov={toxinidir} --cov-report=xml
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ python =
     3.9: py39
     3.8: py38
     3.7: py37
-    3.6: py36
 
 [gh-actions:env]
 PLATFORM =
@@ -25,7 +24,8 @@ setenv =
 passenv =
     GITHUB_TOKEN
 commands =
+    pip install -r requirements_dev.txt
     pip install -e .
     pip install -U pytest pytest-cov coverage
-    pytest --basetemp={envtmpdir} --color=yes --cov={toxinidir} --cov-report=xml
+    pytest ./napari_hub_cli/_tests --online --basetemp={envtmpdir} --color=yes --cov={toxinidir} --cov-report=xml
 


### PR DESCRIPTION
Hi @neuromusic,

Thanks for the invitation to collaborate in the repository :slightly_smiling_face:

I took the liberty to update a little bit the original base code. Here is what I propose in this PR:

* remove `pandas`, `numpy` and `parsesetup` as dependencies. Both of them were not really used (not at all for `numpy` that was here only because of `parsesetup` that wasn't properly packaged) and they drag a lot of cross-dependencies.
* update `setup.cfg`
  * add missing libraries (`requests`) and remove `pandas`, ...
  * remove Python 3.6 support (it wasn't used by automatic tests in github actions)
* update pre-commit config
* update github actions & tox configuration to include Python 3.10 (and drop Python 3.6 in tox)
* update tests
  * update the use of some paths
  * add a mock for `requests`
* update `requirements_dev.txt` (removing unused deps and adding new ones)
 
Regarding the mock for `requests`: now, by default, running `pytest` doesn't fetch information from the internet to get licences information, it gets them from a resource file in the tests. It's then possible to run tests without internet connection. To add back the default behavior, `--online` can be passed to `pytest`. However, as the `_tests` folder is set in an inner package inside of `napari_hub_cli`, pytest fails to activate the parsing of the new option directly (`_tests` should be named `tests` at the root of the project to avoid shipping them with the project). Consequently, to run the tests "online", the command line  is now `pytest napari_hub_cli/_tests --online`. The "online" option is activated for `tox`.

The "biggest" change here is the drop for Python 3.6, should it still be supported by `napari-hub-cli`?