### PR TITLE
Feature/CTC33

### DIFF
--- a/napari_hub_cli/autofix.py
+++ b/napari_hub_cli/autofix.py
@@ -279,7 +279,8 @@ def analyse_then_create_PR(
 
 def autofix_repository(path):
     # creates the checklist
-    result = analyse_local_plugin(path, project_metadata_suite)
+    _, suite = project_metadata_suite
+    result = analyse_local_plugin(path, suite)
 
     # perform modifications on the files
     # modify + add + commit

--- a/napari_hub_cli/checklist/analysis.py
+++ b/napari_hub_cli/checklist/analysis.py
@@ -1,6 +1,7 @@
 # https://api.napari-hub.org/plugins
 
 import csv
+import itertools
 from pathlib import Path
 
 import requests
@@ -220,6 +221,9 @@ def build_csv_dict(dict_results):
             "Analysis Status": analysis_result.status.name,
             "Repository URL": analysis_result.url,
         }
+        for feature in analysis_result.additionals:
+            row[feature.meta.name] = feature.result
+
         for feature in analysis_result.features:
             row[feature.meta.name] = feature.found
             if feature.has_fallback_files:

--- a/napari_hub_cli/checklist/metadata.py
+++ b/napari_hub_cli/checklist/metadata.py
@@ -57,10 +57,11 @@ class PluginAnalysisResult(object):
     repository: Optional[NapariPlugin]
     url: Optional[str]
     title: str
+    additionals: List[BaseFeature]
 
     @classmethod
     def with_status(cls, status, title, url=None):
-        return cls([], status, None, url, title=title)
+        return cls([], status, None, url, title=title, additionals=[])
 
     def __getitem__(self, meta):
         return next((f for f in self.features if f.meta is meta))
@@ -83,6 +84,7 @@ class Requirement(object):
 class RequirementSuite(object):
     title: str
     requirements: List[Requirement]
+    additionals: List[Requirement]
 
 
 def gather_base_feature(meta, main_files):
@@ -152,19 +154,33 @@ def check_feature(meta, main_files, fallbacks):
 
 
 def analyse_requirements(plugin_repo: NapariPlugin, suite: RequirementSuite):
-    result = []
+    reqs_result = []
     requirements = suite.requirements
     for requirement in requirements:
         for feature in requirement.features:
-            result.append(
+            reqs_result.append(
                 check_feature(
                     feature,
                     main_files=requirement.main_files,
                     fallbacks=requirement.fallbacks,
                 )
             )
+    additional_results = []
+    for additional in suite.additionals:
+        for feature in additional.features:
+            additional_results.append(
+                gather_base_feature(
+                    feature,
+                    main_files=additional.main_files,
+                )
+            )
     return PluginAnalysisResult(
-        result, AnalysisStatus.SUCCESS, plugin_repo, url=None, title=suite.title
+        reqs_result,
+        AnalysisStatus.SUCCESS,
+        plugin_repo,
+        url=None,
+        title=suite.title,
+        additionals=additional_results,
     )
 
 
@@ -184,6 +200,8 @@ def analyse_local_plugin(repo_path, requirement_suite):
     """
     repo = Path(repo_path)
     plugin_repo = NapariPlugin(repo)
+    if isinstance(requirement_suite, tuple):
+        _, requirement_suite = requirement_suite
 
     requirements = requirement_suite(plugin_repo)
 
@@ -207,6 +225,10 @@ def display_checklist(analysis_result):
         f"Napari Plugin - {analysis_result.title} Checklist",
         style="bold underline2 blue",
     )
+
+    # Display additional informations
+    for feature in analysis_result.additionals:
+        console.print(f"  {feature.meta.name}: {feature.result}")
 
     # Display summary result
     for feature in analysis_result.features:

--- a/napari_hub_cli/checklist/projectmetadata.py
+++ b/napari_hub_cli/checklist/projectmetadata.py
@@ -6,6 +6,11 @@ LABELS_DOC_URL = "https://github.com/chanzuckerberg/napari-hub/wiki/A-plugin-dev
 
 TITLE = "Documentation"
 
+# Additional data
+HAS_VERSION = MetaFeature("Has explicit version in configuration files", "has_version")
+PLUGIN_VERSION = MetaFeature("Plugin version", "version")
+
+# Checklist
 DISPLAY_NAME = MetaFeature(
     "Display Name", "has_name", "npe2 file: napari.yaml", True, ENTRIES_DOC_URL
 )
@@ -88,6 +93,13 @@ def suite_generator(plugin_repo: NapariPlugin):
 
     return RequirementSuite(
         title=TITLE,
+        additionals=[
+            Requirement(
+                features=[HAS_VERSION, PLUGIN_VERSION],
+                main_files=[pyproject_toml, setup_cfg, setup_py],
+                fallbacks=[],
+            ),
+        ],
         requirements=[
             Requirement(
                 features=[DISPLAY_NAME],

--- a/napari_hub_cli/checklist/projectmetadata.py
+++ b/napari_hub_cli/checklist/projectmetadata.py
@@ -1,9 +1,10 @@
 from ..fs import NapariPlugin
-from .metadata import MetaFeature, Requirement
+from .metadata import MetaFeature, Requirement, RequirementSuite
 
 ENTRIES_DOC_URL = "https://github.com/chanzuckerberg/napari-hub/wiki/Customizing-your-plugin's-listing"
 LABELS_DOC_URL = "https://github.com/chanzuckerberg/napari-hub/wiki/A-plugin-developer%E2%80%99s-guide-to-categories-on-the-napari-hub"
 
+TITLE = "Documentation"
 
 DISPLAY_NAME = MetaFeature(
     "Display Name", "has_name", "npe2 file: napari.yaml", True, ENTRIES_DOC_URL
@@ -75,7 +76,7 @@ LABELS = MetaFeature(
 )
 
 
-def project_metadata_suite(plugin_repo: NapariPlugin):
+def suite_generator(plugin_repo: NapariPlugin):
     pyproject_toml, setup_cfg, setup_py = plugin_repo.pypi_files
     napari_cfg = plugin_repo.config_yml
     description = plugin_repo.description
@@ -85,41 +86,47 @@ def project_metadata_suite(plugin_repo: NapariPlugin):
     long_descr_setup_py = setup_py.long_description()
     long_descr_pyproject_toml = pyproject_toml.long_description()
 
-    return [
-        Requirement(
-            features=[DISPLAY_NAME],
-            main_files=[npe2_yaml],
-            fallbacks=[pyproject_toml, setup_cfg, setup_py],
-        ),
-        Requirement(
-            features=[SUMMARY],
-            main_files=[napari_cfg],
-            fallbacks=[pyproject_toml, setup_cfg, setup_py],
-        ),
-        Requirement(
-            features=[SOURCECODE, AUTHOR, BUGTRACKER, USER_SUPPORT],
-            main_files=[pyproject_toml, setup_cfg, setup_py],
-            fallbacks=[],
-        ),
-        Requirement(
-            features=[VIDEO_SCREENSHOT, USAGE, INTRO, INSTALLATION],
-            main_files=[
-                description,
-            ],
-            fallbacks=[
-                long_descr_setup_cfg,
-                long_descr_setup_py,
-                long_descr_pyproject_toml,
-            ],
-        ),
-        Requirement(
-            features=[CITATION, CITATION_VALID],
-            main_files=[plugin_repo.citation_file],
-            fallbacks=[],
-        ),
-        Requirement(
-            features=[LABELS],
-            main_files=[napari_cfg],
-            fallbacks=[],
-        ),
-    ]
+    return RequirementSuite(
+        title=TITLE,
+        requirements=[
+            Requirement(
+                features=[DISPLAY_NAME],
+                main_files=[npe2_yaml],
+                fallbacks=[pyproject_toml, setup_cfg, setup_py],
+            ),
+            Requirement(
+                features=[SUMMARY],
+                main_files=[napari_cfg],
+                fallbacks=[pyproject_toml, setup_cfg, setup_py],
+            ),
+            Requirement(
+                features=[SOURCECODE, AUTHOR, BUGTRACKER, USER_SUPPORT],
+                main_files=[pyproject_toml, setup_cfg, setup_py],
+                fallbacks=[],
+            ),
+            Requirement(
+                features=[VIDEO_SCREENSHOT, USAGE, INTRO, INSTALLATION],
+                main_files=[
+                    description,
+                ],
+                fallbacks=[
+                    long_descr_setup_cfg,
+                    long_descr_setup_py,
+                    long_descr_pyproject_toml,
+                ],
+            ),
+            Requirement(
+                features=[CITATION, CITATION_VALID],
+                main_files=[plugin_repo.citation_file],
+                fallbacks=[],
+            ),
+            Requirement(
+                features=[LABELS],
+                main_files=[napari_cfg],
+                fallbacks=[],
+            ),
+        ],
+    )
+
+
+project_metadata_suite = (TITLE, suite_generator)

--- a/napari_hub_cli/checklist/projectquality.py
+++ b/napari_hub_cli/checklist/projectquality.py
@@ -6,6 +6,8 @@ TITLE = "Code Quality"
 # Additional data
 HAS_VERSION = MetaFeature("Has explicit version in configuration files", "has_version")
 PLUGIN_VERSION = MetaFeature("Plugin version", "version")
+TOOL_VERSION = MetaFeature("CLI Tool Version","get_cli_tool_version")
+TIMESTAMP = MetaFeature("Execution Timestamp","timestamp")
 
 # Checks
 HAS_SUPPORT_WIN = MetaFeature("Has explicit Windows support", "has_windows_support")
@@ -42,12 +44,18 @@ def suite_generator(plugin_repo: NapariPlugin):
     pyproject_toml = plugin_repo.pyproject_toml
     setup_cfg = plugin_repo.setup_cfg
     setup_py = plugin_repo.setup_py
+    additional_info = plugin_repo.additional_info
     return RequirementSuite(
         title=TITLE,
         additionals=[
             Requirement(
                 features=[HAS_VERSION, PLUGIN_VERSION],
                 main_files=[pyproject_toml, setup_cfg, setup_py],
+                fallbacks=[],
+            ),
+            Requirement(
+                features=[TOOL_VERSION, TIMESTAMP],
+                main_files=[additional_info],
                 fallbacks=[],
             ),
         ],

--- a/napari_hub_cli/checklist/projectquality.py
+++ b/napari_hub_cli/checklist/projectquality.py
@@ -3,6 +3,11 @@ from .metadata import MetaFeature, Requirement, RequirementSuite
 
 TITLE = "Code Quality"
 
+# Additional data
+HAS_VERSION = MetaFeature("Has explicit version in configuration files", "has_version")
+PLUGIN_VERSION = MetaFeature("Plugin version", "version")
+
+# Checks
 HAS_SUPPORT_WIN = MetaFeature("Has explicit Windows support", "has_windows_support")
 HAS_SUPPORT_LINX = MetaFeature("Has explicit Linux support", "has_windows_support")
 HAS_SUPPORT_MACOS = MetaFeature("Has explicit MacOS support", "has_windows_support")
@@ -34,8 +39,18 @@ def suite_generator(plugin_repo: NapariPlugin):
     requirements = plugin_repo.requirements
     condainfo = plugin_repo.condainfo
     license = plugin_repo.license
+    pyproject_toml = plugin_repo.pyproject_toml
+    setup_cfg = plugin_repo.setup_cfg
+    setup_py = plugin_repo.setup_py
     return RequirementSuite(
         title=TITLE,
+        additionals=[
+            Requirement(
+                features=[HAS_VERSION, PLUGIN_VERSION],
+                main_files=[pyproject_toml, setup_cfg, setup_py],
+                fallbacks=[],
+            ),
+        ],
         requirements=[
             Requirement(
                 features=[HAS_OSI_LICENSE],

--- a/napari_hub_cli/checklist/projectquality.py
+++ b/napari_hub_cli/checklist/projectquality.py
@@ -83,6 +83,16 @@ def suite_generator(plugin_repo: NapariPlugin):
                 main_files=[requirements],
                 fallbacks=[],
             ),
+            Requirement(
+                features=[
+                    NPE2_ERRORS,
+                    CONDA_LINUX,
+                    CONDA_WIN,
+                    CONDA_MACOS,
+                ],
+                main_files=[condainfo],
+                fallbacks=[],
+            ),
         ],
     )
 

--- a/napari_hub_cli/checklist/projectquality.py
+++ b/napari_hub_cli/checklist/projectquality.py
@@ -1,5 +1,7 @@
 from ..fs import NapariPlugin
-from .metadata import MetaFeature, Requirement
+from .metadata import MetaFeature, Requirement, RequirementSuite
+
+TITLE = "Code Quality"
 
 HAS_SUPPORT_WIN = MetaFeature("Has explicit Windows support", "has_windows_support")
 HAS_SUPPORT_LINX = MetaFeature("Has explicit Linux support", "has_windows_support")
@@ -28,43 +30,38 @@ HAD_UNKNOWN_ERROR = MetaFeature("Had no unexpected error during dependency analy
 HAS_LICENSE = MetaFeature("Has LICENSE file", "exists")
 
 
-def project_quality_suite(plugin_repo: NapariPlugin):
+def suite_generator(plugin_repo: NapariPlugin):
     requirements = plugin_repo.requirements
     condainfo = plugin_repo.condainfo
     license = plugin_repo.license
-    return [
-        Requirement(
-            features=[HAS_LICENSE, HAS_OSI_LICENSE],
-            main_files=[license],
-            fallbacks=[],
-        ),
-        Requirement(
-            features=[
-                HAD_UNKNOWN_ERROR,
-                HAS_SUPPORT_LINX,
-                HAS_SUPPORT_MACOS,
-                HAS_SUPPORT_WIN,
-                INSTALLABLE_LINUX,
-                INSTALLABLE_MACOS,
-                INSTALLABLE_WIN,
-                ALL_WHEELS_LINUX,
-                ALL_WHEELS_MACOS,
-                ALL_WHEELS_WIN,
-                HAS_C_EXT_LINUX,
-                HAS_C_EXT_MACOS,
-                HAS_C_EXT_WIN,
-            ],
-            main_files=[requirements],
-            fallbacks=[],
-        ),
-        Requirement(
-            features=[
-                NPE2_ERRORS,
-                CONDA_LINUX,
-                CONDA_WIN,
-                CONDA_MACOS,
-            ],
-            main_files=[condainfo],
-            fallbacks=[],
-        ),
-    ]
+    return RequirementSuite(
+        title=TITLE,
+        requirements=[
+            Requirement(
+                features=[HAS_OSI_LICENSE],
+                main_files=[license],
+                fallbacks=[],
+            ),
+            Requirement(
+                features=[
+                    HAS_SUPPORT_LINX,
+                    HAS_SUPPORT_MACOS,
+                    HAS_SUPPORT_WIN,
+                    INSTALLABLE_LINUX,
+                    INSTALLABLE_MACOS,
+                    INSTALLABLE_WIN,
+                    ALL_WHEELS_LINUX,
+                    ALL_WHEELS_MACOS,
+                    ALL_WHEELS_WIN,
+                    HAS_C_EXT_LINUX,
+                    HAS_C_EXT_MACOS,
+                    HAS_C_EXT_WIN,
+                ],
+                main_files=[requirements],
+                fallbacks=[],
+            ),
+        ],
+    )
+
+
+project_quality_suite = (TITLE, suite_generator)

--- a/napari_hub_cli/fs/__init__.py
+++ b/napari_hub_cli/fs/__init__.py
@@ -160,6 +160,7 @@ class NapariPlugin(object):
         )
         from .descriptions import MarkdownDescription
         from .license import License
+        from .additional_info import AdditionalInfo
 
         self.path = path
         self.url = url
@@ -195,6 +196,7 @@ class NapariPlugin(object):
         source_code = pypi_config.sourcecode if pypi_config else None
         plugin_url = self.url or source_code or scrap_git_infos(self.path).get("url")
         self.license = License(path / "LICENSE", plugin_url)
+        self.additional_info = AdditionalInfo(path)
 
     @property
     def summary(self):

--- a/napari_hub_cli/fs/additional_info.py
+++ b/napari_hub_cli/fs/additional_info.py
@@ -1,0 +1,55 @@
+import re
+import os
+from functools import lru_cache
+
+from ..fs import RepositoryFile
+from datetime import datetime
+
+import napari_hub_cli._version as version
+
+
+class AdditionalInfo(RepositoryFile):
+    """
+    Represents a license file in a GitHub repository and provides methods for
+    retrieving its SPDX identifier and checking if it is an OSI-approved license.
+
+    Parameters
+    ----------
+    file : str
+        The path of the license file.
+
+    """
+
+    @property
+    def get_cli_tool_version(self):
+        """
+        Gets the version of the CLI tool as a string.
+
+        Returns
+        -------
+        str
+            The version of the CLI tool.
+        """
+        return version.__version__
+
+
+    @property
+    def timestamp(self):
+        """
+        Gets the current date and time as a formatted string.
+
+        Returns
+        -------
+        str
+            A formatted string representing the current date and time.
+        """
+        now = datetime.now()
+        day = now.day
+        month = now.strftime("%b")
+        year = now.year
+        hours = now.hour
+        minutes = now.minute
+        seconds = now.second
+        formatted_date = f"{day} {month} {year} - {hours}h {minutes}m {seconds}s"
+        return formatted_date
+

--- a/napari_hub_cli/fs/configfiles.py
+++ b/napari_hub_cli/fs/configfiles.py
@@ -20,9 +20,14 @@ class Metadata(object):  # pragma: no cover
     has_bugtracker = Exists("bugtracker")
     has_author = Exists("author")
     has_summary = Exists("summary")
+    has_version = Exists("version")
 
 
 class SetupPy(Metadata, ConfigFile):
+    @property
+    def version(self):
+        return self.data.get("version")
+
     @property
     def name(self):
         return self.data.get("display_name", self.data.get("name"))
@@ -149,6 +154,10 @@ class SetupCfg(Metadata, ConfigFile):
     @property
     def project_urls(self):
         return self.metadata.get("project_urls", "")
+
+    @property
+    def version(self):
+        return self.metadata.get("version")
 
     @property
     def name(self):
@@ -281,6 +290,10 @@ class PyProjectToml(Metadata, ConfigFile):
     @property
     def project_urls(self):
         return self.project_data.get("urls", {})
+
+    @property
+    def version(self):
+        return self.project_data.get("version")
 
     @property
     def name(self):

--- a/tests/resources/pyproject.toml
+++ b/tests/resources/pyproject.toml
@@ -1,6 +1,7 @@
 [project]
 name = "myproject"
 display_name = "myproject"
+version = "0.0.1"
 readme = "README.md"
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/tests/resources/setup2.cfg
+++ b/tests/resources/setup2.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = test-plugin-name
-version = 0.0.1
 author = Jane Doe
 author_email = example@email.com
 license = BSD-3

--- a/tests/resources/setup2.py
+++ b/tests/resources/setup2.py
@@ -14,7 +14,6 @@ def read(fname):
 
 setup(
     name="test-plugin-name",
-    version="0.0.1",
     author="Jane Doe",
     author_email="example@email.com",
     license="BSD-3",

--- a/tests/resources/setup3.py
+++ b/tests/resources/setup3.py
@@ -14,7 +14,7 @@ def read(fname):
 
 setup(
     name="test-plugin-name",
-    version="0.0.1",
+    version="1.0.1",
     author="Jane Doe",
     author_email="example@email.com",
     license="BSD-3",

--- a/tests/test_additional_info.py
+++ b/tests/test_additional_info.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from datetime import datetime
+import pytest
+from napari_hub_cli.fs import NapariPlugin
+
+
+@pytest.fixture(scope="module")
+def test_real_repo():
+    current_path = Path(__file__).parent.absolute()
+    return NapariPlugin(current_path / "resources" / "licenses" / "repo_example1")
+
+
+@pytest.mark.online
+def test_existent_cli_tool_version(test_real_repo):
+    # Test the get_cli_tool_version value
+    additional_info = test_real_repo.additional_info
+    cli_tool_version = additional_info.get_cli_tool_version
+    assert cli_tool_version is not None
+
+
+@pytest.mark.online
+def test_get_cli_tool_version(test_real_repo):
+    # Test the get_cli_tool_version property
+    additional_info = test_real_repo.additional_info
+    cli_tool_version = additional_info.get_cli_tool_version
+    assert isinstance(cli_tool_version, str)
+
+
+@pytest.mark.online
+def test_timestamp(test_real_repo):
+    # Test the timestamp property
+    additional_info = test_real_repo.additional_info
+    formatted_date = additional_info.timestamp
+    assert isinstance(formatted_date, str)
+    assert formatted_date.startswith(datetime.now().strftime("%d %b %Y"))
+
+
+@pytest.mark.online
+def test_existent_timestamp(test_real_repo):
+    # Test the timestamp value
+    additional_info = test_real_repo.additional_info
+    timestamp = additional_info.timestamp
+    assert timestamp is not None
+    assert '202' in timestamp
+
+
+@pytest.mark.online
+def test_inherited_properties(test_real_repo):
+    # Test the inherited properties from RepositoryFile
+    additional_info = test_real_repo.additional_info
+    assert additional_info.exists is not None
+    assert isinstance(additional_info.exists, bool)

--- a/tests/test_autofix.py
+++ b/tests/test_autofix.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import sys
 from contextlib import suppress
+from unittest.mock import DEFAULT
 
 import pytest
 import requests_mock as req
@@ -20,6 +21,8 @@ from napari_hub_cli.checklist import analyse_local_plugin
 from napari_hub_cli.checklist.analysis import DEFAULT_SUITE
 from napari_hub_cli.constants import NAPARI_HUB_API_URL
 from napari_hub_cli.fs import NapariPlugin
+
+_, DEFAULT_SUITE = DEFAULT_SUITE
 
 
 @pytest.fixture

--- a/tests/test_codequality_checklist_repo2.py
+++ b/tests/test_codequality_checklist_repo2.py
@@ -7,6 +7,8 @@ from napari_hub_cli.checklist import analyse_local_plugin, display_checklist
 from napari_hub_cli.checklist.projectquality import project_quality_suite
 from napari_hub_cli.fs import NapariPlugin
 
+_, SUITE = project_quality_suite
+
 
 @pytest.fixture(scope="module")
 def test_repo():
@@ -16,5 +18,5 @@ def test_repo():
 
 # smoke test
 def test_display_checklist(test_repo):
-    result = analyse_local_plugin(test_repo.path, project_quality_suite)
+    result = analyse_local_plugin(test_repo.path, SUITE)
     display_checklist(result)

--- a/tests/test_doc_checklist_faulty.py
+++ b/tests/test_doc_checklist_faulty.py
@@ -15,6 +15,8 @@ from napari_hub_cli.checklist.projectmetadata import (
 )
 from napari_hub_cli.fs import NapariPlugin
 
+_, DEFAULT_SUITE = DEFAULT_SUITE
+
 
 @pytest.fixture(scope="module")
 def test_repo():

--- a/tests/test_doc_checklist_repo1.py
+++ b/tests/test_doc_checklist_repo1.py
@@ -15,8 +15,6 @@ from napari_hub_cli.checklist.projectmetadata import (
 from napari_hub_cli.citation import create_cff_citation
 from napari_hub_cli.fs import NapariPlugin
 
-_, DEFAULT_SUITE = DEFAULT_SUITE
-
 
 @pytest.fixture(scope="module")
 def test_repo():

--- a/tests/test_doc_checklist_repo1.py
+++ b/tests/test_doc_checklist_repo1.py
@@ -15,6 +15,8 @@ from napari_hub_cli.checklist.projectmetadata import (
 from napari_hub_cli.citation import create_cff_citation
 from napari_hub_cli.fs import NapariPlugin
 
+_, DEFAULT_SUITE = DEFAULT_SUITE
+
 
 @pytest.fixture(scope="module")
 def test_repo():

--- a/tests/test_doc_checklist_repo2.py
+++ b/tests/test_doc_checklist_repo2.py
@@ -14,6 +14,8 @@ from napari_hub_cli.checklist.projectmetadata import (
 )
 from napari_hub_cli.fs import NapariPlugin
 
+_, DEFAULT_SUITE = DEFAULT_SUITE
+
 
 @pytest.fixture(scope="module")
 def test_repo():

--- a/tests/test_file_access.py
+++ b/tests/test_file_access.py
@@ -44,6 +44,9 @@ def test_setup_py(resources):
     assert file.has_bugtracker is False
     assert file.has_summary is True
 
+    assert file.has_version is True
+    assert file.version == "0.0.1"
+
     assert file.find_npe2() is None
 
     assert file.classifiers
@@ -69,6 +72,9 @@ def test_setup2_py(resources):
     assert file.has_bugtracker is False
     assert file.has_summary is True
 
+    assert file.has_version is False
+    assert file.version is None
+
     assert file.find_npe2() is not None
     assert file.find_npe2() == resources / "module_path" / "napari.yaml"
 
@@ -89,6 +95,9 @@ def test_setup3_py(resources):
     assert file.has_author is True
     assert file.has_bugtracker is False
     assert file.has_summary is True
+
+    assert file.has_version is True
+    assert file.version == "1.0.1"
 
     assert file.find_npe2() is None
 
@@ -113,6 +122,9 @@ def test_setup_cfg(resources):
     assert file.has_author is True
     assert file.has_bugtracker is False
     assert file.has_summary is True
+
+    assert file.has_version is True
+    assert file.version == "0.0.1"
 
     assert file.find_npe2() is None
 
@@ -145,6 +157,9 @@ def test_setup2_cfg(resources):
     assert file.has_author is True
     assert file.has_bugtracker is False
     assert file.has_summary is True
+
+    assert file.has_version is False
+    assert file.version is None
 
     assert file.find_npe2() is None
 
@@ -197,6 +212,9 @@ def test_pyproject_toml(resources):
     assert file.has_author is False
     assert file.has_bugtracker is False
     assert file.has_summary is False
+
+    assert file.has_version is True
+    assert file.version == "0.0.1"
 
     assert file.find_npe2() is not None
 

--- a/tests/test_remote_analysis.py
+++ b/tests/test_remote_analysis.py
@@ -23,6 +23,8 @@ from napari_hub_cli.utils import (
     get_repository_url,
 )
 
+_, DEFAULT_SUITE = DEFAULT_SUITE
+
 
 @pytest.fixture
 def napari_hub(requests_mock):
@@ -76,12 +78,15 @@ def test_get_plugin_url(napari_hub):
 
 
 def test_no_result_analysis():
-    result = PluginAnalysisResult.with_status(AnalysisStatus.UNACCESSIBLE_REPOSITORY)
+    result = PluginAnalysisResult.with_status(
+        AnalysisStatus.UNACCESSIBLE_REPOSITORY, title="my list"
+    )
 
     assert result.features == []
     assert result.status is AnalysisStatus.UNACCESSIBLE_REPOSITORY
     assert result.url is None
     assert result.repository is None
+    assert result.title == "my list"
 
 
 def test_analyse_remote_plugin_bad_url(napari_hub):


### PR DESCRIPTION
What's added with this PR
---

- timestamp for the command execution, providing info regarding `Day - Month - Year, Hour - minutes - seconds`
- version of the napari-hub-cli tool, information stored in `napari-hub-cli._version.__version__`
- version of the plugin that was checked, retrieved from the config files

![image](https://github.com/chanzuckerberg/napari-hub-cli/assets/99416933/12ab4194-aece-4fb5-810c-48bd0cd79802)

As seen below the unit tests for the additional information code are passing

![image](https://github.com/chanzuckerberg/napari-hub-cli/assets/99416933/d8fcb12a-a5f2-4dec-b64e-27b1856f0590)



